### PR TITLE
Remove Moshi Dependency, rewrite implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,9 @@ authors = ["Jadon Clugston"]
 version = "1.0.1"
 
 [deps]
-DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
-Moshi = "2e0e35c7-a2e4-4343-998d-7ef72827ed2d"
+
 
 [compat]
 DocStringExtensions = "0.9.5"
@@ -20,6 +19,7 @@ julia = "1.10"
 [extras]
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 
 [targets]
-test = ["SafeTestsets", "Test"]
+test = ["Test", "SafeTestsets", "DocStringExtensions"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 DocStringExtensions = "0.9.5"
 Logging = "1.1.0"
 LoggingExtras = "1.1.0"
-Moshi = "0.3.6"
 SafeTestsets = "0.1.0"
 julia = "1.10"
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -27,7 +27,7 @@ mutable struct MyOptions
     
     function MyOptions(;
         startup = Verbosity.Info(),
-        progress = Verbosity.None(),
+        progress = Verbosity.Silent(),
         warnings = Verbosity.Warn()
     )
         new(startup, progress, warnings)
@@ -58,9 +58,9 @@ The type parameter `T` determines whether verbosity is enabled:
 verbose = MyVerbosity{true}(MyOptions())
 
 # Emit messages at different levels
-@SciMLMessage("Application starting...", verbose, :startup, :options)
-@SciMLMessage("Processing item 1/100", verbose, :progress, :options)
-@SciMLMessage("Memory usage high", verbose, :warnings, :options)
+@SciMLMessage("Application starting...", verbose, :startup)
+@SciMLMessage("Processing item 1/100", verbose, :progress)
+@SciMLMessage("Memory usage high", verbose, :warnings)
 nothing # hide
 ```
 
@@ -71,7 +71,7 @@ SciMLLogging provides several built-in verbosity levels:
 ```@example tutorial2
 using SciMLLogging
 
-Verbosity.None()    # No output
+Verbosity.Silent()  # No output
 Verbosity.Info()    # Informational messages
 Verbosity.Warn()    # Warning messages
 Verbosity.Error()   # Error messages
@@ -102,7 +102,7 @@ verbose = MyVerbosity2{true}(MyOptions2())
 iter = 5
 total = 100
 
-@SciMLMessage(verbose, :progress, :options) do
+@SciMLMessage(verbose, :progress) do
     percentage = iter / total * 100
     "Progress: $iter/$total ($(round(percentage, digits=1))%)"
 end
@@ -132,7 +132,7 @@ end
 silent = MyVerbosity3{false}(MyOptions3())
 
 # This compiles to nothing - no runtime overhead
-@SciMLMessage("This won't be shown", silent, :startup, :options)
+@SciMLMessage("This won't be shown", silent, :startup)
 println("Message was not shown because verbosity is disabled")
 ```
 
@@ -158,8 +158,8 @@ using SciMLLogging
 is_verbose = verbosity_to_bool(Verbosity.Info())  # Returns true
 println("Verbosity.Info() converts to: $is_verbose")
 
-is_verbose = verbosity_to_bool(Verbosity.None())  # Returns false
-println("Verbosity.None() converts to: $is_verbose")
+is_verbose = verbosity_to_bool(Verbosity.Silent())  # Returns false
+println("Verbosity.Silent() converts to: $is_verbose")
 ```
 
 ## Custom Logger
@@ -193,7 +193,7 @@ verbose = LoggerTestVerbosity{true}(LoggerTestOptions())
 
 # Use the logger
 with_logger(logger) do
-    @SciMLMessage("This warning is logged", verbose, :test, :options)
+    @SciMLMessage("This warning is logged", verbose, :test)
 end
 
 # Clean up
@@ -234,21 +234,21 @@ end
 
 # Solver function
 function my_solver(problem, verbose::SolverVerbosity)
-    @SciMLMessage("Initializing solver...", verbose, :initialization, :options)
+    @SciMLMessage("Initializing solver...", verbose, :initialization)
     
     for i in 1:100
         # Do iteration work...
         
-        @SciMLMessage(verbose, :iterations, :options) do
+        @SciMLMessage(verbose, :iterations) do
             "Iteration $i: residual = $(round(rand(), digits=4))"
         end
         
         if rand() < 0.05  # Converged (5% chance per iteration for demo)
-            @SciMLMessage("Converged at iteration $i", verbose, :convergence, :options)
+            @SciMLMessage("Converged at iteration $i", verbose, :convergence)
             return i
         end
     end
-    @SciMLMessage("Failed to converge", verbose, :convergence, :options)
+    @SciMLMessage("Failed to converge", verbose, :convergence)
     return nothing
 end
 
@@ -289,13 +289,13 @@ end
     
     # Test that message is logged at correct level
     @test_logs (:info, "Test message") begin
-        @SciMLMessage("Test message", verbose, :level, :options)
+        @SciMLMessage("Test message", verbose, :level)
     end
-    
+
     # Test that disabled verbosity produces no output
     silent = TestVerbosity{false}(TestOptions())
     @test_logs min_level=Logging.Debug begin
-        @SciMLMessage("Should not appear", silent, :level, :options)
+        @SciMLMessage("Should not appear", silent, :level)
     end
 end
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -21,9 +21,9 @@ using SciMLLogging
 using Logging
 
 mutable struct MyOptions
-    startup::Verbosity.Type
-    progress::Verbosity.Type
-    warnings::Verbosity.Type
+    startup::Verbosity.LogLevel
+    progress::Verbosity.LogLevel
+    warnings::Verbosity.LogLevel
     
     function MyOptions(;
         startup = Verbosity.Info(),

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -1,7 +1,5 @@
 module SciMLLogging
 
-import Moshi.Data: @data
-import Moshi.Match: @match
 import Logging
 using LoggingExtras
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,7 +93,7 @@ function emit_message(message::String, verbose::AbstractVerbositySpecifier{true}
 end 
 
 function emit_message(
-    f, verbose::AbstractVerbositySpecifier{true}, option::Nothing, file, line, _module)
+    f::Function, verbose::AbstractVerbositySpecifier{true}, level::Nothing, file, line, _module)
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,22 @@
+"""
+    Verbosity
+
+A module defining verbosity levels and presets for SciMLLogging.
+
+## Log Levels
+- `Silent`: No output
+- `Info`: Informational messages
+- `Warn`: Warning messages
+- `Error`: Error messages
+- `Level(n)`: Custom log level with integer value `n`
+
+## Verbosity Presets
+- `None`: Minimal verbosity preset
+- `All`: Maximum verbosity preset
+- `Minimal`: Basic verbosity preset
+- `Standard`: Standard verbosity preset
+- `Detailed`: Detailed verbosity preset
+"""
 module Verbosity
     abstract type LogLevel end
     struct Silent <: LogLevel end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,15 +59,17 @@ end
 function emit_message(message::String, verbose::V,
         option, file, line, _module) where {V <: AbstractVerbositySpecifier{true}}
     level = message_level(verbose, option)
-
-    if !isnothing(level)
-        Base.@logmsg level message _file=file _line=line _module=_module
-    end
+    Base.@logmsg level message _file=file _line=line _module=_module
 end
 
 function emit_message(
         f, verbose::AbstractVerbositySpecifier{false}, option, file, line, _module)
 end
+
+function emit_message(
+    f, verbose::AbstractVerbositySpecifier{true}, option::Verbosity.Silent, file, line, _module)
+end
+
 
 """
 A macro that emits a log message based on the log level specified in the `option` of the `AbstractVerbositySpecifier` supplied.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,7 +93,7 @@ and use them in the log message.
 
 ```julia
 # String message
-@SciMLMessage("Hello", verbose, :test1, :options)
+@SciMLMessage("Hello", verbose, :test1)
 
 # Function for lazy evaluation
 x = 10
@@ -119,7 +119,7 @@ macro SciMLMessage(f_or_message, verb, option, group)
     file = string(__source__.file)
     _module = __module__
     return :(emit_message(
-        $(esc(f_or_message)), $(esc(verb)), $option, $file, $line, $_module))
+        $(esc(f_or_message)), $(esc(verb)), message_level($(esc(verb)), $(esc(option))), $file, $line, $_module))
 end
 
 """

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,65 +1,103 @@
 using SciMLLogging
-using SciMLLogging: @match, Verbosity, AbstractVerbositySpecifier, @SciMLMessage
+using SciMLLogging: Verbosity, AbstractVerbositySpecifier, @SciMLMessage
 using Logging
 using Test
 
-# Structs for testing package
-mutable struct TestOptionsVerbosity
-    test1::Verbosity.Type
-    test2::Verbosity.Type
-    test3::Verbosity.Type
-    test4::Verbosity.Type
+# Structs for testing package - simplified structure
+struct TestVerbosity{T} <: AbstractVerbositySpecifier{T}
+    test1::Verbosity.LogLevel
+    test2::Verbosity.LogLevel
+    test3::Verbosity.LogLevel
+    test4::Verbosity.LogLevel
 
-    function TestOptionsVerbosity(;
+    function TestVerbosity{T}(;
             test1 = Verbosity.Warn(),
             test2 = Verbosity.Info(),
             test3 = Verbosity.Error(),
-            test4 = Verbosity.None()
-    )
-        new(test1, test2, test3, test4)
-    end
-
-    function TestOptionsVerbosity(verbose::Verbosity.Type)
-        @match verbose begin
-            Verbosity.None() => new(fill(
-                Verbosity.None(), length(fieldnames(TestOptionsVerbosity)))...)
-            Verbosity.Info() => new(fill(
-                Verbosity.Info(), length(fieldnames(TestOptionsVerbosity)))...)
-            Verbosity.Warn() => new(fill(
-                Verbosity.Warn(), length(fieldnames(TestOptionsVerbosity)))...)
-            Verbosity.Error() => new(fill(
-                Verbosity.Error(), length(fieldnames(TestOptionsVerbosity)))...)
-            Verbosity.Default() => TestOptionsVerbosity()
-            Verbosity.Edge() => TestOptionsVerbosity(
-                test1 = Verbosity.Info(),
-                test2 = Verbosity.Info(),
-                test3 = Verbosity.Info(),
-                test4 = Verbosity.Info()
-            )
-            _ => @error "Not a valid choice for verbosity."
-        end
+            test4 = Verbosity.Silent()) where T
+        new{T}(test1, test2, test3, test4)
     end
 end
 
-struct TestVerbosity{T} <: AbstractVerbositySpecifier{T}
-    options::TestOptionsVerbosity
+TestVerbosity() = TestVerbosity{true}()
+TestVerbosity(enabled::Bool) = enabled ? TestVerbosity{true}() : TestVerbosity{false}()
+
+function TestVerbosity(preset::Verbosity.VerbosityPreset)
+    if preset isa Verbosity.None
+        TestVerbosity{false}()
+    elseif preset isa Verbosity.All
+        TestVerbosity{true}(
+            test1 = Verbosity.Info(),
+            test2 = Verbosity.Info(),
+            test3 = Verbosity.Info(),
+            test4 = Verbosity.Info()
+        )
+    elseif preset isa Verbosity.Minimal
+        TestVerbosity{true}(
+            test1 = Verbosity.Error(),
+            test2 = Verbosity.Silent(),
+            test3 = Verbosity.Error(),
+            test4 = Verbosity.Silent()
+        )
+    else
+        TestVerbosity{true}()
+    end
 end
 
 # Tests 
 
 @testset "Basic tests" begin
-    verbose = TestVerbosity{true}(TestOptionsVerbosity())
+    verbose = TestVerbosity{true}()
 
-    @test_logs (:warn, "Test1") @SciMLMessage("Test1", verbose, :test1, :options)
-    @test_logs (:info, "Test2") @SciMLMessage("Test2", verbose, :test2, :options)
-    @test_logs (:error, "Test3") @SciMLMessage("Test3", verbose, :test3, :options)
-    @test_logs min_level = Logging.Debug @SciMLMessage("Test4", verbose, :test4, :options)
+    @test_logs (:warn, "Test1") @SciMLMessage("Test1", verbose, :test1)
+    @test_logs (:info, "Test2") @SciMLMessage("Test2", verbose, :test2)
+    @test_logs (:error, "Test3") @SciMLMessage("Test3", verbose, :test3)
+    @test_logs min_level = Logging.Debug @SciMLMessage("Test4", verbose, :test4)
 
     x = 30
     y = 30
 
-    @test_logs (:warn, "Test1: 60") @SciMLMessage(verbose, :test1, :options) do
+    @test_logs (:warn, "Test1: 60") @SciMLMessage(verbose, :test1) do
         z = x + y
         "Test1: $z"
+    end
+end
+
+@testset "Verbosity presets" begin
+    # Test with different presets
+    verbose_all = TestVerbosity(Verbosity.All())
+    verbose_minimal = TestVerbosity(Verbosity.Minimal())
+    verbose_none = TestVerbosity(Verbosity.None())
+
+    # All preset should log info level messages
+    @test_logs (:info, "All preset test") @SciMLMessage("All preset test", verbose_all, :test1)
+
+    # Minimal preset should only log errors
+    @test_logs (:error, "Minimal preset test") @SciMLMessage("Minimal preset test", verbose_minimal, :test1)
+
+    # None preset should not log anything
+    @test_logs min_level = Logging.Debug @SciMLMessage("None preset test", verbose_none, :test1)
+end
+
+@testset "Disabled verbosity" begin
+    verbose_off = TestVerbosity{false}()
+
+    # Should not log anything when verbosity is disabled
+    @test_logs min_level = Logging.Debug @SciMLMessage("Should not appear", verbose_off, :test1)
+    @test_logs min_level = Logging.Debug @SciMLMessage("Should not appear", verbose_off, :test2)
+end
+
+@testset "Backwards compatibility" begin
+    verbose = TestVerbosity{true}()
+
+    # Test 4-argument version for backwards compatibility
+    # The group argument should be ignored but the macro should still work
+    @test_logs (:warn, "Backwards compat test") @SciMLMessage("Backwards compat test", verbose, :test1, :ignored_group)
+    @test_logs (:info, "Backwards compat test 2") @SciMLMessage("Backwards compat test 2", verbose, :test2, :another_ignored_group)
+
+    # Test function-based version with 4 arguments
+    x = 42
+    @test_logs (:error, "Backwards function test: 42") @SciMLMessage(verbose, :test3, :ignored_group) do
+        "Backwards function test: $x"
     end
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

  I redesigned the SciMLLogging verbosity system to simiplify it and get rid of the Moshi.jl dependency. 

  Key Changes

  Simplified Macro API

  - Before: @SciMLMessage("message", verbosity, 
  :option, :group)
  - After: @SciMLMessage("message", verbosity, 
  :option)
  - The 4-parameter version still works for
  backwards compatibility (group parameter is
  ignored, but it also didn't affect the logging message before anyway. )

  Flattened Verbosity Structure

  The old nested group approach required accessing
  options through multiple levels:
  # Old way
  verbosity.error_control.default_lu_fallback

  # New way  
  verbosity.default_lu_fallback

 Now the implementer of the AbstractVerbositySpecifiers are not required to have different groups. 

 # Enhanced Verbosity Types

  - Renamed Verbosity.None() to Verbosity.Silent()
  - Added new VerbosityPreset system with concrete
  types:
    - Verbosity.None - Disables all logging
    - Verbosity.All - Enables all logging at Info level
    - Verbosity.Minimal - Only critical errors
    - Verbosity.Standard - Reasonable defaults
    - Verbosity.Detailed - Verbose debugging output

  Core Function Changes

  - message_level() now takes 2 parameters instead
  of 3
  - emit_message() functions work with levels
  directly
  - Removed dependency on pattern matching (@match)
  - Added method for disabled verbosity specifiers
 

  Benefits

  - Reduced API complexity (fewer required
  parameters)
  - Better performance through direct property
  access
  - Eliminated nested structure navigation
  - Better preset system
 - Verbosity.Silent() can now be checked at compile time, and can possibly be "compiled out"