### PR TITLE
Update Names to Prevent Collisions with Logging.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Consistent logging patterns across the SciML ecosystem
 # Basic Usage
 
 ```julia
-using SciMLLogging
+using SciMLLogging: AbstractVerbositySpecifier, MessageLevel, WarnLevel, InfoLevel, Silent, ErrorLevel
 using Logging
 
 # Create a simple verbosity structure

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ SciMLLogging supports several verbosity levels:
   - `InfoLevel()`: Informational messages
   - `WarnLevel()`: Warning messages
   - `ErrorLevel()`: Error messages
-  - `CustomLevel(n)`: Custom logging level (using Julia's LogLevel(n))
+  - `CustomLevel(n)`: Custom logging level with integer value `n`
 
 # Creating Custom Verbosity Types
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ using Logging
 
 # Create a simple verbosity structure
 struct MyVerbosity{T} <: AbstractVerbositySpecifier{T}
-    algorithm_choice::SciMLLogging.LogLevel
-    iteration_progress::SciMLLogging.LogLevel
+    algorithm_choice::MessageLevel
+    iteration_progress::MessageLevel
 
     function MyVerbosity{T}(;
-            algorithm_choice = SciMLLogging.Warn(),
-            iteration_progress = SciMLLogging.Info()
+            algorithm_choice = WarnLevel(),
+            iteration_progress = InfoLevel()
     ) where {T}
         new{T}(algorithm_choice, iteration_progress)
     end
@@ -58,10 +58,10 @@ end
 SciMLLogging supports several verbosity levels:
 
   - `Silent()`: No output
-  - `Info()`: Informational messages
-  - `Warn()`: Warning messages
-  - `Error()`: Error messages
-  - `Level(n)`: Custom logging level (using Julia's LogLevel(n))
+  - `InfoLevel()`: Informational messages
+  - `WarnLevel()`: Warning messages
+  - `ErrorLevel()`: Error messages
+  - `CustomLevel(n)`: Custom logging level (using Julia's LogLevel(n))
 
 # Creating Custom Verbosity Types
 
@@ -73,16 +73,16 @@ SciMLLogging supports several verbosity levels:
 ```julia
 # Main verbosity struct with direct LogLevel fields
 struct MyAppVerbosity{T} <: AbstractVerbositySpecifier{T}
-    solver_iterations::SciMLLogging.LogLevel
-    solver_convergence::SciMLLogging.LogLevel
-    performance_timing::SciMLLogging.LogLevel
-    performance_memory::SciMLLogging.LogLevel
+    solver_iterations::MessageLevel
+    solver_convergence::MessageLevel
+    performance_timing::MessageLevel
+    performance_memory::MessageLevel
 
     function MyAppVerbosity{T}(;
-            solver_iterations = SciMLLogging.Info(),
-            solver_convergence = SciMLLogging.Warn(),
-            performance_timing = SciMLLogging.Silent(),
-            performance_memory = SciMLLogging.Silent()
+            solver_iterations = InfoLevel(),
+            solver_convergence = WarnLevel(),
+            performance_timing = Silent(),
+            performance_memory = Silent()
     ) where {T}
         new{T}(solver_iterations, solver_convergence, performance_timing, performance_memory)
     end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,12 +8,12 @@ CurrentModule = SciMLLogging
 
 ```@docs
 AbstractVerbositySpecifier
-LogLevel
+MessageLevel
 Silent
-Info
-Warn
-Error
-Level
+InfoLevel
+WarnLevel
+ErrorLevel
+CustomLevel
 VerbosityPreset
 None
 All

--- a/docs/src/developer_tutorial.md
+++ b/docs/src/developer_tutorial.md
@@ -8,7 +8,7 @@ SciMLLogging.jl provides three main components for package developers:
 
 1. `AbstractVerbositySpecifier{T}` - Base type for creating custom verbosity types
 2. `@SciMLMessage` - Macro for emitting conditional log messages
-3. Verbosity levels - Predefined log levels (`Silent`, `Info`, `Warn`, `Error`, `Level(n)`)
+3. Verbosity levels - Predefined log levels (`Silent`, `InfoLevel`, `WarnLevel`, `ErrorLevel`, `CustomLevel(n)`)
 
 ## Step 1: Design Your Verbosity Interface
 
@@ -26,16 +26,16 @@ Define a struct that inherits from `AbstractVerbositySpecifier{T}`:
 using SciMLLogging
 
 struct MySolverVerbosity{T} <: AbstractVerbositySpecifier{T}
-    initialization::LogLevel
-    iterations::LogLevel
-    convergence::LogLevel
-    warnings::LogLevel
+    initialization::MessageLevel
+    iterations::MessageLevel
+    convergence::MessageLevel
+    warnings::MessageLevel
 
     function MySolverVerbosity{T}(;
-        initialization = Info(),
+        initialization = InfoLevel(),
         iterations = Silent(),
-        convergence = Info(),
-        warnings = Warn()
+        convergence = InfoLevel(),
+        warnings = WarnLevel()
     ) where T
         new{T}(initialization, iterations, convergence, warnings)
     end
@@ -65,17 +65,17 @@ function MySolverVerbosity(preset::VerbosityPreset)
         MySolverVerbosity{false}()
     elseif preset isa All
         MySolverVerbosity{true}(
-            initialization = Info(),
-            iterations = Info(),
-            convergence = Info(),
-            warnings = Warn()
+            initialization = InfoLevel(),
+            iterations = InfoLevel(),
+            convergence = InfoLevel(),
+            warnings = WarnLevel()
         )
     elseif preset isa Minimal
         MySolverVerbosity{true}(
             initialization = Silent(),
             iterations = Silent(),
-            convergence = Error(),
-            warnings = Error()
+            convergence = ErrorLevel(),
+            warnings = ErrorLevel()
         )
     else
         MySolverVerbosity{true}()  # Default
@@ -157,10 +157,10 @@ Provide clear documentation for your users:
 Controls verbosity output from MySolver functions.
 
 # Keyword Arguments
-- `initialization = Info()`: Messages about solver setup
+- `initialization = InfoLevel()`: Messages about solver setup
 - `iterations = Silent()`: Per-iteration progress messages
-- `convergence = Info()`: Convergence/failure notifications
-- `warnings = Warn()`: Warning messages during solving
+- `convergence = InfoLevel()`: Convergence/failure notifications
+- `warnings = WarnLevel()`: Warning messages during solving
 
 # Constructors
 - `MySolverVerbosity()`: Default enabled verbosity
@@ -237,11 +237,11 @@ For specialized needs, you can create custom log levels:
 
 ```julia
 struct MySolverVerbosity{T} <: AbstractVerbositySpecifier{T}
-    debug::LogLevel
+    debug::MessageLevel
     # ... other fields
 
     function MySolverVerbosity{T}(;
-        debug = Level(-1000),  # Custom level below Info
+        debug = CustomLevel(-1000),  # Custom level below Info
         # ... other defaults
     ) where T
         new{T}(debug, ...)
@@ -260,9 +260,9 @@ using SciMLLogging
 import SciMLLogging: AbstractVerbositySpecifier
 
 struct ExampleVerbosity{T} <: AbstractVerbositySpecifier{T}
-    progress::LogLevel
+    progress::MessageLevel
 
-    ExampleVerbosity{T}(progress = Info()) where T = new{T}(progress)
+    ExampleVerbosity{T}(progress = InfoLevel()) where T = new{T}(progress)
 end
 
 ExampleVerbosity() = ExampleVerbosity{true}()

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -21,14 +21,14 @@ using SciMLLogging
 using Logging
 
 struct MyVerbosity{T} <: AbstractVerbositySpecifier{T}
-    startup::SciMLLogging.LogLevel
-    progress::SciMLLogging.LogLevel
-    warnings::SciMLLogging.LogLevel
+    startup::MessageLevel
+    progress::MessageLevel
+    warnings::MessageLevel
 
     function MyVerbosity{T}(;
-        startup = SciMLLogging.Info(),
-        progress = SciMLLogging.Silent(),
-        warnings = SciMLLogging.Warn()
+        startup = InfoLevel(),
+        progress = Silent(),
+        warnings = WarnLevel()
     ) where T
         new{T}(startup, progress, warnings)
     end
@@ -60,11 +60,11 @@ SciMLLogging provides several built-in verbosity levels:
 ```@example tutorial2
 using SciMLLogging
 
-SciMLLogging.Silent()  # No output
-SciMLLogging.Info()    # Informational messages
-SciMLLogging.Warn()    # Warning messages
-SciMLLogging.Error()   # Error messages
-SciMLLogging.Level(-1000)  # Custom log level with integer n
+Silent()  # No output
+InfoLevel()    # Informational messages
+WarnLevel()    # Warning messages
+ErrorLevel()   # Error messages
+CustomLevel(-1000)  # Custom log level with integer n
 ```
 
 ## Dynamic Messages
@@ -77,9 +77,9 @@ using Logging
 
 # Define the verbosity system (same as before)
 struct MyVerbosity2{T} <: AbstractVerbositySpecifier{T}
-    progress::SciMLLogging.LogLevel
+    progress::MessageLevel
 
-    MyVerbosity2{T}(progress = SciMLLogging.Info()) where T = new{T}(progress)
+    MyVerbosity2{T}(progress = SciMLLogging.InfoLevel()) where T = new{T}(progress)
 end
 
 verbose = MyVerbosity2{true}()
@@ -106,9 +106,9 @@ using SciMLLogging
 using Logging
 
 struct MyVerbosity3{T} <: AbstractVerbositySpecifier{T}
-    startup::SciMLLogging.LogLevel
+    startup::MessageLevel
 
-    MyVerbosity3{T}(startup = SciMLLogging.Info()) where T = new{T}(startup)
+    MyVerbosity3{T}(startup = InfoLevel()) where T = new{T}(startup)
 end
 
 # Disabled verbosity
@@ -128,7 +128,7 @@ For compatibility with packages using integer verbosity levels:
 ```@example tutorial5
 using SciMLLogging
 
-level = verbosity_to_int(SciMLLogging.Warn())  # Returns 2
+level = verbosity_to_int(WarnLevel())  # Returns 2
 ```
 
 ### Converting to Boolean
@@ -138,10 +138,10 @@ For packages using boolean verbosity flags:
 ```@example tutorial6
 using SciMLLogging
 
-is_verbose = verbosity_to_bool(SciMLLogging.Info())  # Returns true
-println("SciMLLogging.Info() converts to: $is_verbose")
+is_verbose = verbosity_to_bool(InfoLevel())  # Returns true
+println("SciMLLogging.InfoLevel() converts to: $is_verbose")
 
-is_verbose = verbosity_to_bool(SciMLLogging.Silent())  # Returns false
+is_verbose = verbosity_to_bool(Silent())  # Returns false
 println("SciMLLogging.Silent() converts to: $is_verbose")
 ```
 
@@ -164,9 +164,9 @@ logger = SciMLLogger(
 
 # Define a simple verbosity system for testing
 struct LoggerTestVerbosity{T} <: AbstractVerbositySpecifier{T}
-    test::SciMLLogging.LogLevel
+    test::MessageLevel
 
-    LoggerTestVerbosity{T}(test = SciMLLogging.Warn()) where T = new{T}(test)
+    LoggerTestVerbosity{T}(test = WarnLevel()) where T = new{T}(test)
 end
 
 verbose = LoggerTestVerbosity{true}()
@@ -194,14 +194,14 @@ Random.seed!(123) # For reproducibility
 
 # Create verbosity type
 struct SolverVerbosity{T} <: AbstractVerbositySpecifier{T}
-    initialization::SciMLLogging.LogLevel
-    iterations::SciMLLogging.LogLevel
-    convergence::SciMLLogging.LogLevel
+    initialization::MessageLevel
+    iterations::MessageLevel
+    convergence::MessageLevel
 
     function SolverVerbosity{T}(;
-        initialization = SciMLLogging.Info(),
-        iterations = SciMLLogging.Silent(),
-        convergence = SciMLLogging.Info()
+        initialization = InfoLevel(),
+        iterations = Silent(),
+        convergence = InfoLevel()
     ) where T
         new{T}(initialization, iterations, convergence)
     end
@@ -251,9 +251,9 @@ using Test
 
 # Define a simple verbosity system for testing
 struct TestVerbosity{T} <: AbstractVerbositySpecifier{T}
-    level::SciMLLogging.LogLevel
+    level::MessageLevel
 
-    TestVerbosity{T}(level = SciMLLogging.Info()) where T = new{T}(level)
+    TestVerbosity{T}(level = InfoLevel()) where T = new{T}(level)
 end
 
 @testset "Verbosity Tests" begin

--- a/docs/src/user_tutorial.md
+++ b/docs/src/user_tutorial.md
@@ -13,17 +13,17 @@ using SciMLLogging
 
 # Example VerbositySpecifier from a hypothetical solver package
 struct SolverVerbosity{T} <: AbstractVerbositySpecifier{T}
-    initialization::LogLevel    # Controls startup messages
-    iterations::LogLevel        # Controls per-iteration output
-    convergence::LogLevel       # Controls convergence messages
-    warnings::LogLevel          # Controls warning messages
+    initialization::MessageLevel    # Controls startup messages
+    iterations::MessageLevel        # Controls per-iteration output
+    convergence::MessageLevel       # Controls convergence messages
+    warnings::MessageLevel          # Controls warning messages
 end
 ```
 
 **What this means:**
 - **`T` parameter**: Controls whether logging is enabled (`T=true`) or disabled (`T=false`)
 - **Each field**: Represents a category of messages the package can emit
-- **LogLevel values**: Can be `Silent()`, `Info()`, `Warn()`, `Error()`, or `Level(n)` for custom levels
+- **MessageLevel values**: Can be `Silent()`, `InfoLevel()`, `WarnLevel()`, `ErrorLevel()`, or `CustomLevel(n)` for custom levels
 
 When `T=false`, all logging is disabled with zero runtime overhead. When `T=true`, each category can be individually controlled.
 
@@ -38,10 +38,10 @@ using SomePackage  # A package that uses SciMLLogging
 result = solve_problem(problem)
 
 # Silent mode (no output)
-result = solve_problem(problem, verbose = SciMLLogging.None())
+result = solve_problem(problem, verbose = None())
 
 # Verbose mode (show more details)
-result = solve_problem(problem, verbose = SciMLLogging.Detailed())
+result = solve_problem(problem, verbose = Detailed())
 ```
 
 ## Understanding Verbosity Levels
@@ -80,10 +80,10 @@ Here's an example of how one might use a packages `AbstractVerbositySpecifier` i
 ```julia
 # Example: Customizing a solver's verbosity
 verbose_settings = SolverVerbosity{true}(
-    initialization = Info(),      # Show startup messages
+    initialization = InfoLevel(),      # Show startup messages
     iterations = Silent(),        # Don't show each iteration
-    convergence = Info(),         # Show when it converges
-    warnings = Warn()            # Show warnings
+    convergence = InfoLevel(),         # Show when it converges
+    warnings = WarnLevel()            # Show warnings
 )
 
 result = solve(problem, verbose = verbose_settings)
@@ -91,10 +91,10 @@ result = solve(problem, verbose = verbose_settings)
 
 **Explanation of the example above:**
 - `SolverVerbosity{true}()` creates an enabled verbosity specifier
-- `initialization = Info()` means startup messages will be shown as informational logs
+- `initialization = InfoLevel()` means startup messages will be shown as informational logs
 - `iterations = Silent()` means iteration progress won't be shown at all
-- `convergence = Info()` means convergence messages will be shown as informational logs
-- `warnings = Warn()` means warnings will be shown as warning-level logs
+- `convergence = InfoLevel()` means convergence messages will be shown as informational logs
+- `warnings = WarnLevel()` means warnings will be shown as warning-level logs
 
 ## Working with Different Output Backends
 
@@ -188,10 +188,10 @@ result = solve_problem(problematic_case, verbose = All())
 
 # Or create custom settings to focus on specific aspects
 debug_verbose = SolverVerbosity{true}(
-    initialization = Info(),
-    iterations = Info(),        # Now show iterations for debugging
-    convergence = Info(),
-    warnings = Warn()
+    initialization = InfoLevel(),
+    iterations = InfoLevel(),        # Now show iterations for debugging
+    convergence = InfoLevel(),
+    warnings = WarnLevel()
 )
 
 result = solve_problem(problematic_case, verbose = debug_verbose)
@@ -207,7 +207,7 @@ production_verbose = SolverVerbosity{true}(
     initialization = Silent(),   # Don't show routine startup
     iterations = Silent(),       # Don't show progress
     convergence = Silent(),      # Don't show normal completion
-    warnings = Warn()           # But do show problems
+    warnings = WarnLevel()           # But do show problems
 )
 
 result = solve_problem(problem, verbose = production_verbose)
@@ -222,10 +222,10 @@ Typical solver verbosity options:
 ```julia
 # Show convergence info but not each iteration
 solver_verbose = SolverVerbosity{true}(
-    initialization = Info(),
+    initialization = InfoLevel(),
     iterations = Silent(),
-    convergence = Info(),
-    warnings = Warn()
+    convergence = InfoLevel(),
+    warnings = WarnLevel()
 )
 
 solution = solve(problem, solver_verbose)
@@ -239,9 +239,9 @@ Optimization packages might have different categories:
 # Focus on optimization progress
 opt_verbose = OptimizerVerbosity{true}(
     initialization = Silent(),
-    objective = Info(),      # Show objective function values
-    constraints = Warn(),    # Show constraint violations
-    convergence = Info()
+    objective = InfoLevel(),      # Show objective function values
+    constraints = WarnLevel(),    # Show constraint violations
+    convergence = InfoLevel()
 )
 
 result = optimize(objective, constraints, opt_verbose)

--- a/docs/src/user_tutorial.md
+++ b/docs/src/user_tutorial.md
@@ -49,9 +49,9 @@ result = solve_problem(problem, verbose = Detailed())
 SciMLLogging packages typically categorize their messages into different types:
 
 - **Silent**: No output at all
-- **Info**: General informational messages
-- **Warn**: Warning messages about potential issues
-- **Error**: Error messages (usually still shown even in quiet modes)
+- **InfoLevel**: General informational messages
+- **WarnLevel**: Warning messages about potential issues
+- **ErrorLevel**: Error messages (usually still shown even in quiet modes)
 
 ## Common Usage Patterns
 

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -8,7 +8,8 @@ include("verbosity.jl")
 include("utils.jl")
 
 # Export public API
-export AbstractVerbositySpecifier, VerbosityPreset
+export AbstractVerbositySpecifier, VerbosityPreset, MessageLevel
+export InfoLevel, WarnLevel, ErrorLevel, CustomLevel
 export @SciMLMessage
 export verbosity_to_int, verbosity_to_bool
 export SciMLLogger

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -9,7 +9,7 @@ include("utils.jl")
 
 # Export public API
 export AbstractVerbositySpecifier, VerbosityPreset, MessageLevel
-export InfoLevel, WarnLevel, ErrorLevel, CustomLevel
+export InfoLevel, WarnLevel, ErrorLevel, CustomLevel, Silent
 export @SciMLMessage
 export verbosity_to_int, verbosity_to_bool
 export SciMLLogger

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,13 +16,13 @@ function message_level(verbose::AbstractVerbositySpecifier{true}, option)
 
     if opt_level isa Silent
         return nothing
-    elseif opt_level isa Info
+    elseif opt_level isa InfoLevel
         return Logging.Info
-    elseif opt_level isa Warn
+    elseif opt_level isa WarnLevel
         return Logging.Warn
-    elseif opt_level isa Error
+    elseif opt_level isa ErrorLevel
         return Logging.Error
-    elseif opt_level isa Level
+    elseif opt_level isa CustomLevel
         return Logging.LogLevel(opt_level.level)
     else
         return nothing
@@ -115,28 +115,28 @@ macro SciMLMessage(f_or_message, verb, option, group)
 end
 
 """
-        `verbosity_to_int(verb::LogLevel)`
-    Takes a `LogLevel` and gives a corresponding integer value.
+        `verbosity_to_int(verb::MessageLevel)`
+    Takes a `MessageLevel` and gives a corresponding integer value.
     Verbosity settings that use integers or enums that hold integers are relatively common.
     This provides an interface so that these packages can be used with SciMLVerbosity. Each of the basic verbosity levels
     are mapped to an integer.
 
     - Silent() => 0
-    - Info() => 1
-    - Warn() => 2
-    - Error() => 3
-    - Level(i) => i
+    - InfoLevel() => 1
+    - WarnLevel() => 2
+    - ErrorLevel() => 3
+    - CustomLevel(i) => i
 """
-function verbosity_to_int(verb::LogLevel)
+function verbosity_to_int(verb::MessageLevel)
     if verb isa Silent
         return 0
-    elseif verb isa Info
+    elseif verb isa InfoLevel
         return 1
-    elseif verb isa Warn
+    elseif verb isa WarnLevel
         return 2
-    elseif verb isa Error
+    elseif verb isa ErrorLevel
         return 3
-    elseif verb isa Level
+    elseif verb isa CustomLevel
         return verb.level
     else
         return 0
@@ -144,13 +144,13 @@ function verbosity_to_int(verb::LogLevel)
 end
 
 """
-        `verbosity_to_bool(verb::LogLevel)`
-    Takes a `LogLevel` and gives a corresponding boolean value.
+        `verbosity_to_bool(verb::MessageLevel)`
+    Takes a `MessageLevel` and gives a corresponding boolean value.
     Verbosity settings that use booleans are relatively common.
     This provides an interface so that these packages can be used with SciMLVerbosity.
     If the verbosity is `Silent`, then `false` is returned. Otherwise, `true` is returned.
 """
-function verbosity_to_bool(verb::LogLevel)
+function verbosity_to_bool(verb::MessageLevel)
     if verb isa Silent
         return false
     else

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -86,14 +86,6 @@ a verbosity specifier with `T=false`, providing zero runtime overhead.
 struct None <: VerbosityPreset end
 
 """
-    All <: VerbosityPreset
-
-Preset that enables maximum verbosity. All message categories are typically
-set to show informational messages or their appropriate levels.
-"""
-struct All <: VerbosityPreset end
-
-"""
     Minimal <: VerbosityPreset
 
 Preset that shows only essential messages. Typically includes only warnings,
@@ -119,3 +111,11 @@ analysis. Shows most or all available message categories to help with
 troubleshooting and understanding program behavior.
 """
 struct Detailed <: VerbosityPreset end
+
+"""
+    All <: VerbosityPreset
+
+Preset that enables maximum verbosity. All message categories are typically
+set to show informational messages or their appropriate levels.
+"""
+struct All <: VerbosityPreset end

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -5,10 +5,10 @@ Abstract base type for all verbosity log levels in SciMLLogging.
 
 Log levels determine the severity/importance of messages. Concrete subtypes include:
 - `Silent`: No output
-- `Info`: Informational messages
-- `Warn`: Warning messages
-- `Error`: Error messages
-- `Level(n)`: Custom log level with integer value `n`
+- `InfoLevel`: Informational messages
+- `WarnLevel`: Warning messages
+- `ErrorLevel`: Error messages
+- `CustomLevel(n)`: Custom log level with integer value `n`
 """
 abstract type MessageLevel end
 
@@ -21,7 +21,7 @@ no messages will be emitted for that category.
 struct Silent <: MessageLevel end
 
 """
-    Info <: MessageLevel
+    InfoLevel <: MessageLevel
 
 Informational log level. Messages at this level provide general information
 about the progress or state of the computation.
@@ -29,7 +29,7 @@ about the progress or state of the computation.
 struct InfoLevel <: MessageLevel end
 
 """
-    Warn <: MessageLevel
+    WarnLevel <: MessageLevel
 
 Warning log level. Messages at this level indicate potential issues or
 situations that may require attention but don't prevent execution.
@@ -37,7 +37,7 @@ situations that may require attention but don't prevent execution.
 struct WarnLevel <: MessageLevel end
 
 """
-    Error <: MessageLevel
+    ErrorLevel <: MessageLevel
 
 Error log level. Messages at this level indicate serious problems or
 failures in the computation.

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -1,5 +1,5 @@
 """
-    LogLevel
+    MessageLevel
 
 Abstract base type for all verbosity log levels in SciMLLogging.
 
@@ -10,42 +10,42 @@ Log levels determine the severity/importance of messages. Concrete subtypes incl
 - `Error`: Error messages
 - `Level(n)`: Custom log level with integer value `n`
 """
-abstract type LogLevel end
+abstract type MessageLevel end
 
 """
-    Silent <: LogLevel
+    Silent <: MessageLevel
 
 Log level that produces no output. When a message category is set to `Silent()`,
 no messages will be emitted for that category.
 """
-struct Silent <: LogLevel end
+struct Silent <: MessageLevel end
 
 """
-    Info <: LogLevel
+    Info <: MessageLevel
 
 Informational log level. Messages at this level provide general information
 about the progress or state of the computation.
 """
-struct Info <: LogLevel end
+struct InfoLevel <: MessageLevel end
 
 """
-    Warn <: LogLevel
+    Warn <: MessageLevel
 
 Warning log level. Messages at this level indicate potential issues or
 situations that may require attention but don't prevent execution.
 """
-struct Warn <: LogLevel end
+struct WarnLevel <: MessageLevel end
 
 """
-    Error <: LogLevel
+    Error <: MessageLevel
 
 Error log level. Messages at this level indicate serious problems or
 failures in the computation.
 """
-struct Error <: LogLevel end
+struct ErrorLevel <: MessageLevel end
 
 """
-    Level(n::Int) <: LogLevel
+    CustomLevel(n::Int) <: MessageLevel
 
 Custom log level with integer value `n`. This allows creating custom
 severity levels beyond the standard Info/Warn/Error hierarchy.
@@ -54,11 +54,11 @@ Higher integer values typically indicate higher priority/severity.
 
 # Example
 ```julia
-debug_level = Level(-1000)  # Very low priority debug messages
-critical_level = Level(1000)  # Very high priority critical messages
+debug_level = CustomLevel(-1000)  # Very low priority debug messages
+critical_level = CustomLevel(1000)  # Very high priority critical messages
 ```
 """
-struct Level <: LogLevel
+struct CustomLevel <: MessageLevel
     level::Int
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using SciMLLogging
-using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, VerbosityPreset
+using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, VerbosityPreset, MessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent
 using Logging
 using Test
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -5,16 +5,16 @@ using Test
 
 # Structs for testing package - simplified structure
 struct TestVerbosity{T} <: AbstractVerbositySpecifier{T}
-    test1::SciMLLogging.LogLevel
-    test2::SciMLLogging.LogLevel
-    test3::SciMLLogging.LogLevel
-    test4::SciMLLogging.LogLevel
+    test1::MessageLevel
+    test2::MessageLevel
+    test3::MessageLevel
+    test4::MessageLevel
 
     function TestVerbosity{T}(;
-            test1 = SciMLLogging.Warn(),
-            test2 = SciMLLogging.Info(),
-            test3 = SciMLLogging.Error(),
-            test4 = SciMLLogging.Silent()) where {T}
+            test1 = WarnLevel(),
+            test2 = InfoLevel(),
+            test3 = ErrorLevel(),
+            test4 = Silent()) where {T}
         new{T}(test1, test2, test3, test4)
     end
 end
@@ -27,17 +27,17 @@ function TestVerbosity(preset::VerbosityPreset)
         TestVerbosity{false}()
     elseif preset isa SciMLLogging.All
         TestVerbosity{true}(
-            test1 = SciMLLogging.Info(),
-            test2 = SciMLLogging.Info(),
-            test3 = SciMLLogging.Info(),
-            test4 = SciMLLogging.Info()
+            test1 = InfoLevel(),
+            test2 = InfoLevel(),
+            test3 = InfoLevel(),
+            test4 = InfoLevel()
         )
-    elseif preset isa SciMLLogging.Minimal
+    elseif preset isa Minimal
         TestVerbosity{true}(
-            test1 = SciMLLogging.Error(),
-            test2 = SciMLLogging.Silent(),
-            test3 = SciMLLogging.Error(),
-            test4 = SciMLLogging.Silent()
+            test1 = ErrorLevel(),
+            test2 = Silent(),
+            test3 = ErrorLevel(),
+            test4 = Silent()
         )
     else
         TestVerbosity{true}()
@@ -65,9 +65,9 @@ end
 
 @testset "Verbosity presets" begin
     # Test with different presets
-    verbose_all = TestVerbosity(SciMLLogging.All())
-    verbose_minimal = TestVerbosity(SciMLLogging.Minimal())
-    verbose_none = TestVerbosity(SciMLLogging.None())
+    verbose_all = TestVerbosity(All())
+    verbose_minimal = TestVerbosity(Minimal())
+    verbose_none = TestVerbosity(None())
 
     # All preset should log info level messages
     @test_logs (:info, "All preset test") @SciMLMessage("All preset test", verbose_all, :test1)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using SciMLLogging
-using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, VerbosityPreset, MessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All
+using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, VerbosityPreset, MessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All, Minimal
 using Logging
 using Test
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using SciMLLogging
-using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, VerbosityPreset, MessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent
+using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, VerbosityPreset, MessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All
 using Logging
 using Test
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Logging.jl already exports things like LogLevel, Info, Warn, Error, etc. So to prevent annoying naming collisions the names here should change. 
