### PR TITLE
Use one type parameter to enable or disable logging 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,147 @@
+# Changelog
+
+All notable changes to SciMLLogging.jl will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0]
+
+### Breaking
+
+- **`MessageLevel` is now a concrete struct**, no longer an abstract type with
+  per-level subtypes. `Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`,
+  `ErrorLevel`, and `CustomLevel` are now `MessageLevel` constants (or, for
+  `CustomLevel`, a constructor alias). `AbstractMessageLevel` remains as a
+  backward-compatible type alias for `MessageLevel`.
+  - `Silent()`, `InfoLevel()`, etc. still work — calling a `MessageLevel`
+    instance returns itself, so existing code is unaffected.
+  - Code that dispatched on the old subtypes (e.g. `f(::WarnLevel)`) needs to
+    be rewritten to compare values (`level == WarnLevel`).
+
+- **`AbstractVerbositySpecifier` is now parametric on `{Enabled}`**. Concrete
+  specifier types must subtype `AbstractVerbositySpecifier{Enabled}` for some
+  `Enabled` parameter. The macro-generated specifiers do this automatically;
+  hand-written specifiers must be updated:
+  ```julia
+  # Before
+  struct MyVerbosity <: AbstractVerbositySpecifier
+      option_a
+      option_b
+  end
+
+  # After
+  struct MyVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+      option_a::MessageLevel
+      option_b::MessageLevel
+  end
+  ```
+  The `Enabled` parameter drives a compile-time short-circuit in
+  `@SciMLMessage`: instances constructed via `None()` produce
+  `MyVerbosity{false}`, and `get_message_level(::AbstractVerbositySpecifier{false}, ::Any)`
+  returns `nothing`, eliminating logging branches at compile time.
+
+### Added
+
+- **`specifiers = (...)` block in `@verbosity_specifier`** — declare fields that
+  hold a sub-specifier or preset. Each declared specifier becomes its own free
+  type parameter on the generated struct, so the field is concretely typed at
+  the instance level. This preserves inference when the sub-specifier is
+  forwarded to a downstream API, and lets a package hold a sub-specifier whose
+  type it does not depend on at definition time (e.g. DiffEqBase holding a
+  NonlinearVerbosity without depending on NonlinearSolve).
+  ```julia
+  @verbosity_specifier DEVerbosity begin
+      toggles    = (:dt_select, :step_rejected)
+      specifiers = (:nonlinear_verbosity, :linear_verbosity)
+      presets = (
+          Standard = (
+              dt_select           = InfoLevel(),
+              step_rejected       = WarnLevel(),
+              nonlinear_verbosity = Standard(),       # preset OR
+              linear_verbosity    = LinearVerbosity(), # sub-spec instance
+          ),
+          # ...
+      )
+      groups = ()
+  end
+  ```
+
+  The macro generates roughly:
+
+  ```julia
+  # Toggle-only specifier (no `specifiers` block): single Enabled type
+  # parameter; toggle fields use a wider Union for backward compatibility.
+  struct VerbSpec{Enabled} <: AbstractVerbositySpecifier{Enabled}
+      toggle1::Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
+      toggle2::Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
+      # ...
+  end
+
+  # With a `specifiers = (:nonlinear_verbosity, :linear_verbosity)` block:
+  # one extra type parameter per declared specifier; toggle fields are concrete
+  # `MessageLevel`; specifier fields are typed by the per-instance type param,
+  # so they specialize to whatever concrete sub-spec or preset the user passes.
+  struct DEVerbosity{Enabled, __SPEC_T_1, __SPEC_T_2} <: AbstractVerbositySpecifier{Enabled}
+      dt_select::MessageLevel
+      step_rejected::MessageLevel
+      nonlinear_verbosity::__SPEC_T_1
+      linear_verbosity::__SPEC_T_2
+  end
+
+  # A partial-application constructor lets the existing call sites keep
+  # writing `DEVerbosity{true}(...)`; Julia infers the trailing type params
+  # from the positional arg types.
+  function DEVerbosity{Enabled}(t1, t2, s1, s2) where {Enabled}
+      return DEVerbosity{Enabled, typeof(s1), typeof(s2)}(t1, t2, s1, s2)
+  end
+
+  # Plus a preset constructor per declared preset (None ⇒ {false}, others ⇒ {true}):
+  DEVerbosity(::Standard) = DEVerbosity{true}(InfoLevel(), WarnLevel(), Standard(), LinearVerbosity())
+  DEVerbosity(::None)     = DEVerbosity{false}(Silent(),    Silent(),    None(),     None())
+  # ...
+
+  # Plus the keyword constructor with `preset=`, group kwargs, and field kwargs.
+  ```
+
+  Concrete instance types end up looking like
+  `DEVerbosity{true, Standard, LinearVerbosity{true}}` — both type params are
+  concrete, so `verb.linear_verbosity` returns a concrete type and inference
+  flows through into downstream APIs.
+
+  Specifier fields accept either an `AbstractVerbositySpecifier` instance or
+  an `AbstractVerbosityPreset` singleton; the kwarg constructor validates this.
+
+### Changed
+
+- **Toggle fields are now concretely typed `::MessageLevel`** when a
+  `specifiers` block is declared. Without a `specifiers` block, toggle fields
+  retain the previous wider Union typing for backward compatibility.
+- **`@SciMLMessage` short-circuits at compile time** when the verbosity
+  specifier has `Enabled === false`. The
+  `get_message_level(::AbstractVerbositySpecifier{false}, ::Any)` method
+  returns `nothing`, the macro guards on that, and the compiler eliminates
+  the logging branch for disabled specifiers.
+
+### Migration notes for downstream packages
+
+1. **Manually-defined verbosity specifiers**: add the `{Enabled}` type
+   parameter and update the abstract supertype to
+   `AbstractVerbositySpecifier{Enabled}`. Default kwarg constructors should
+   return `MyVerbosity{true}(...)`; the `None()` preset constructor should
+   return `MyVerbosity{false}(...)`.
+2. **Macro-using specifiers with sub-specs**: move sub-specifier fields out of
+   `toggles` and into a new `specifiers` block to opt into the parametric
+   typing. No changes are required for toggle-only specifiers.
+3. **Functions accepting a `verbose=` argument** should accept both an
+   `AbstractVerbositySpecifier` instance and an `AbstractVerbosityPreset`
+   singleton — that's what specifier fields can hand them. The macro-generated
+   `name(::PresetType)` constructors satisfy this on the construction side; on
+   the consumption side it is a pattern to follow.
+4. **Code that introspected `MessageLevel` subtypes via dispatch** (e.g.
+   `function f(::InfoLevel)`) must be rewritten to compare values
+   (`level == InfoLevel`) since the subtypes no longer exist.
+
+## Earlier versions
+
+For changes prior to 2.0.0, see the git history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ErrorLevel`, and `CustomLevel` are now `MessageLevel` constants (or, for
   `CustomLevel`, a constructor alias). The `AbstractMessageLevel` name has been
   removed — code referring to it must be updated to use `MessageLevel`.
-  - `Silent()`, `InfoLevel()`, etc. still work — calling a `MessageLevel`
+  - `Silent`, `InfoLevel`, etc. still work — calling a `MessageLevel`
     instance returns itself, so existing call-site syntax is unaffected.
   - Code that dispatched on the old subtypes (e.g. `f(::WarnLevel)`) needs to
     be rewritten to compare values (`level == WarnLevel`).
@@ -57,8 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       sub_specifiers = (:nonlinear_verbosity, :linear_verbosity)
       presets = (
           Standard = (
-              dt_select           = InfoLevel(),
-              step_rejected       = WarnLevel(),
+              dt_select           = InfoLevel,
+              step_rejected       = WarnLevel,
               nonlinear_verbosity = Standard(),       # preset OR
               linear_verbosity    = LinearVerbosity(), # sub-spec instance
           ),
@@ -98,8 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end
 
   # Plus a preset constructor per declared preset (None ⇒ {false}, others ⇒ {true}):
-  DEVerbosity(::Standard) = DEVerbosity{true}(InfoLevel(), WarnLevel(), Standard(), LinearVerbosity())
-  DEVerbosity(::None)     = DEVerbosity{false}(Silent(),    Silent(),    None(),     None())
+  DEVerbosity(::Standard) = DEVerbosity{true}(InfoLevel, WarnLevel, Standard(), LinearVerbosity())
+  DEVerbosity(::None)     = DEVerbosity{false}(Silent,    Silent,    None(),     None())
   # ...
 
   # Plus the keyword constructor with `preset=`, group kwargs, and field kwargs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`MessageLevel` is now a concrete struct**, no longer an abstract type with
   per-level subtypes. `Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`,
   `ErrorLevel`, and `CustomLevel` are now `MessageLevel` constants (or, for
-  `CustomLevel`, a constructor alias). `AbstractMessageLevel` remains as a
-  backward-compatible type alias for `MessageLevel`.
+  `CustomLevel`, a constructor alias). The `AbstractMessageLevel` name has been
+  removed — code referring to it must be updated to use `MessageLevel`.
   - `Silent()`, `InfoLevel()`, etc. still work — calling a `MessageLevel`
-    instance returns itself, so existing code is unaffected.
+    instance returns itself, so existing call-site syntax is unaffected.
   - Code that dispatched on the old subtypes (e.g. `f(::WarnLevel)`) needs to
     be rewritten to compare values (`level == WarnLevel`).
 
@@ -43,17 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`specifiers = (...)` block in `@verbosity_specifier`** — declare fields that
-  hold a sub-specifier or preset. Each declared specifier becomes its own free
-  type parameter on the generated struct, so the field is concretely typed at
-  the instance level. This preserves inference when the sub-specifier is
-  forwarded to a downstream API, and lets a package hold a sub-specifier whose
-  type it does not depend on at definition time (e.g. DiffEqBase holding a
-  NonlinearVerbosity without depending on NonlinearSolve).
+- **`sub_specifiers = (...)` block in `@verbosity_specifier`** — declare fields
+  that hold another verbosity specifier or preset. Each declared sub_specifier
+  becomes its own free type parameter on the generated struct, so the field is
+  concretely typed at the instance level. This preserves inference when the
+  sub-specifier is forwarded to a downstream API, and lets a package hold a
+  sub-specifier whose type it does not depend on at definition time
+  (e.g. DiffEqBase holding a NonlinearVerbosity without depending on
+  NonlinearSolve).
   ```julia
   @verbosity_specifier DEVerbosity begin
-      toggles    = (:dt_select, :step_rejected)
-      specifiers = (:nonlinear_verbosity, :linear_verbosity)
+      toggles        = (:dt_select, :step_rejected)
+      sub_specifiers = (:nonlinear_verbosity, :linear_verbosity)
       presets = (
           Standard = (
               dt_select           = InfoLevel(),
@@ -70,18 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The macro generates roughly:
 
   ```julia
-  # Toggle-only specifier (no `specifiers` block): single Enabled type
-  # parameter; toggle fields use a wider Union for backward compatibility.
+  # Toggle-only specifier: single Enabled type parameter; toggle fields are
+  # concretely typed `::MessageLevel`.
   struct VerbSpec{Enabled} <: AbstractVerbositySpecifier{Enabled}
-      toggle1::Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
-      toggle2::Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
+      toggle1::MessageLevel
+      toggle2::MessageLevel
       # ...
   end
 
-  # With a `specifiers = (:nonlinear_verbosity, :linear_verbosity)` block:
-  # one extra type parameter per declared specifier; toggle fields are concrete
-  # `MessageLevel`; specifier fields are typed by the per-instance type param,
-  # so they specialize to whatever concrete sub-spec or preset the user passes.
+  # With `sub_specifiers = (:nonlinear_verbosity, :linear_verbosity)`:
+  # one extra type parameter per declared sub_specifier; sub_specifier fields
+  # are typed by their per-instance type param, so they specialize to whatever
+  # concrete sub-spec or preset the user passes.
   struct DEVerbosity{Enabled, __SPEC_T_1, __SPEC_T_2} <: AbstractVerbositySpecifier{Enabled}
       dt_select::MessageLevel
       step_rejected::MessageLevel
@@ -89,9 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       linear_verbosity::__SPEC_T_2
   end
 
-  # A partial-application constructor lets the existing call sites keep
-  # writing `DEVerbosity{true}(...)`; Julia infers the trailing type params
-  # from the positional arg types.
+  # A partial-application constructor lets the generated preset/kwarg call
+  # sites keep writing `DEVerbosity{true}(...)`; Julia infers the trailing
+  # type params from the positional arg types.
   function DEVerbosity{Enabled}(t1, t2, s1, s2) where {Enabled}
       return DEVerbosity{Enabled, typeof(s1), typeof(s2)}(t1, t2, s1, s2)
   end
@@ -105,18 +106,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
   Concrete instance types end up looking like
-  `DEVerbosity{true, Standard, LinearVerbosity{true}}` — both type params are
-  concrete, so `verb.linear_verbosity` returns a concrete type and inference
-  flows through into downstream APIs.
+  `DEVerbosity{true, Standard, LinearVerbosity{true}}` — both sub_specifier
+  type params are concrete, so `verb.linear_verbosity` returns a concrete type
+  and inference flows through into downstream APIs.
 
-  Specifier fields accept either an `AbstractVerbositySpecifier` instance or
-  an `AbstractVerbosityPreset` singleton; the kwarg constructor validates this.
+  Sub_specifier fields accept either an `AbstractVerbositySpecifier` instance
+  or an `AbstractVerbosityPreset` singleton; the kwarg constructor validates
+  this. Toggle fields are restricted to `MessageLevel` values.
 
 ### Changed
 
-- **Toggle fields are now concretely typed `::MessageLevel`** when a
-  `specifiers` block is declared. Without a `specifiers` block, toggle fields
-  retain the previous wider Union typing for backward compatibility.
+- **Toggle fields are always concretely typed `::MessageLevel`**. Previously a
+  toggle could hold a preset or another verbosity specifier as a workaround for
+  hierarchical configuration; that role now belongs to the new `sub_specifiers`
+  block. Macro-generated specifiers reject non-`MessageLevel` values for
+  toggles at the kwarg constructor.
 - **`@SciMLMessage` short-circuits at compile time** when the verbosity
   specifier has `Enabled === false`. The
   `get_message_level(::AbstractVerbositySpecifier{false}, ::Any)` method
@@ -130,9 +134,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `AbstractVerbositySpecifier{Enabled}`. Default kwarg constructors should
    return `MyVerbosity{true}(...)`; the `None()` preset constructor should
    return `MyVerbosity{false}(...)`.
-2. **Macro-using specifiers with sub-specs**: move sub-specifier fields out of
-   `toggles` and into a new `specifiers` block to opt into the parametric
-   typing. No changes are required for toggle-only specifiers.
+2. **Macro-using specifiers with sub-specs**: any field that previously held a
+   preset or another verbosity specifier as a "toggle" must move out of
+   `toggles` and into a new `sub_specifiers` block. Toggles are now strictly
+   `MessageLevel`-only. Toggle-only specifiers don't need any change.
 3. **Functions accepting a `verbose=` argument** should accept both an
    `AbstractVerbositySpecifier` instance and an `AbstractVerbosityPreset`
    singleton — that's what specifier fields can hand them. The macro-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - **`MessageLevel` is now a concrete struct**, no longer an abstract type with
-  per-level subtypes. `Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`,
-  `ErrorLevel`, and `CustomLevel` are now `MessageLevel` constants (or, for
-  `CustomLevel`, a constructor alias). The `AbstractMessageLevel` name has been
-  removed — code referring to it must be updated to use `MessageLevel`.
-  - `Silent`, `InfoLevel`, etc. still work — calling a `MessageLevel`
+  per-level subtypes. `Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`, and
+  `ErrorLevel` are now `MessageLevel` constants. Custom levels are constructed
+  by calling `MessageLevel(n)` directly. The `AbstractMessageLevel` and
+  `CustomLevel` names have been removed — code referring to them must be
+  updated to use `MessageLevel`.
+  - `Silent()`, `InfoLevel()`, etc. still work — calling a `MessageLevel`
     instance returns itself, so existing call-site syntax is unaffected.
   - Code that dispatched on the old subtypes (e.g. `f(::WarnLevel)`) needs to
     be rewritten to compare values (`level == WarnLevel`).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLLogging"
 uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 authors = ["Jadon Clugston"]
-version = "1.9.1"
+version = "2.0.0"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ standard severities:
   - `InfoLevel`: Informational messages
   - `WarnLevel`: Warning messages
   - `ErrorLevel`: Error messages
-  - `CustomLevel(n)`: Custom level with integer value `n`
+  - `MessageLevel(n)`: Custom level with integer value `n`
 
 # Verbosity Presets
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/SciMLLogging/dev/)
 [![Build Status](https://github.com/SciML/SciMLVerbosity.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/SciML/SciMLVerbosity.jl/actions/workflows/CI.yml?query=branch%3Amain)
 
-A flexible verbosity control system for the SciML ecosystem that allows fine-grained control over logging, warnings.
+A flexible verbosity control system for the SciML ecosystem that allows fine-grained control over logging and warnings.
 
 Installation
 
@@ -13,104 +13,158 @@ Pkg.add("SciMLLogging")
 
 SciMLLogging.jl provides a structured approach to controlling verbosity in scientific computing workflows. It enables:
 
-Fine-grained control over which messages are displayed and at what levels
-Hierarchical organization of verbosity settings by component and message type
-
-Consistent logging patterns across the SciML ecosystem
+- Fine-grained control over which messages are displayed and at what levels
+- Hierarchical organization of verbosity settings by component and message type
+- Consistent logging patterns across the SciML ecosystem
+- Compile-time elimination of disabled logging branches via the `{Enabled}` type parameter
 
 # Basic Usage
 
+The recommended way to define a verbosity specifier is the `@verbosity_specifier` macro. It generates a parametric struct, all the constructors, preset support, and group keyword arguments in one declaration:
+
 ```julia
-using SciMLLogging: AbstractVerbositySpecifier, AbstractMessageLevel, WarnLevel, InfoLevel, Silent, ErrorLevel
-using ConcreteStructs: @concrete
-using Logging
+using SciMLLogging
 
-# Create a simple verbosity structure
-@concrete struct MyVerbosity <: AbstractVerbositySpecifier
-    algorithm_choice
-    iteration_progress
+@verbosity_specifier MyVerbosity begin
+    toggles = (:algorithm_choice, :iteration_progress)
+
+    presets = (
+        None = (
+            algorithm_choice   = Silent(),
+            iteration_progress = Silent(),
+        ),
+        Standard = (
+            algorithm_choice   = WarnLevel(),
+            iteration_progress = InfoLevel(),
+        ),
+        All = (
+            algorithm_choice   = InfoLevel(),
+            iteration_progress = InfoLevel(),
+        ),
+    )
+
+    groups = ()
 end
 
-# Constructor with defaults
-function MyVerbosity(;
-        algorithm_choice = WarnLevel(),
-        iteration_progress = InfoLevel()
-)
-    MyVerbosity(algorithm_choice, iteration_progress)
-end
-
-# Create verbosity instance
+# Create a verbosity instance — defaults to the Standard preset
 verbose = MyVerbosity()
+
+# Or pick a preset
+verbose = MyVerbosity(Standard())
+
+# Or override individual toggles
+verbose = MyVerbosity(algorithm_choice = ErrorLevel())
 
 # Log messages at different levels
 @SciMLMessage("Selected algorithm: GMRES", verbose, :algorithm_choice)
 @SciMLMessage("Iteration 5/100 complete", verbose, :iteration_progress)
 
-# Use a function to create the message
+# Use a function form to defer message construction (only evaluated if the
+# toggle is non-Silent)
 @SciMLMessage(verbose, :iteration_progress) do
     iter = 10
     total = 100
-    progress = iter/total * 100
-    "Iteration $iter/$total complete ($(round(progress, digits=1))%)"
+    progress = iter / total * 100
+    "Iteration $iter/$total complete ($(round(progress, digits = 1))%)"
 end
 ```
 
-# Verbosity Levels
+# Message Levels
 
-SciMLLogging supports several verbosity levels:
+SciMLLogging defines a single concrete `MessageLevel` type with the following
+standard severities:
 
   - `Silent()`: No output
+  - `DebugLevel()`: Debug messages
   - `InfoLevel()`: Informational messages
   - `WarnLevel()`: Warning messages
   - `ErrorLevel()`: Error messages
-  - `CustomLevel(n)`: Custom logging level with integer value `n`
+  - `CustomLevel(n)`: Custom level with integer value `n`
 
-# Creating Custom Verbosity Types
+# Verbosity Presets
 
- 1. Define a structure for each group of verbosity options
- 2. Create a main verbosity struct that inherits from AbstractVerbositySpecifier
- 3. Use `@concrete` from ConcreteStructs.jl for better performance (recommended)
- 4. Define constructors for easy creation and default values
-    Example:
+Five standard presets are provided: `None()`, `Minimal()`, `Standard()`,
+`Detailed()`, and `All()`. The macro generates a constructor for each preset
+declared in the `presets = (...)` block. Constructing with `None()` produces a
+`{false}` instance — this is what triggers compile-time elimination of logging
+branches at `@SciMLMessage` call sites.
 
 ```julia
-using ConcreteStructs: @concrete
+verbose_off = MyVerbosity(None())   # MyVerbosity{false} — disabled at the type level
+verbose_on  = MyVerbosity(Standard()) # MyVerbosity{true}
+```
 
-# Main verbosity struct with direct message level fields
-@concrete struct MyAppVerbosity <: AbstractVerbositySpecifier
-    solver_iterations
-    solver_convergence
-    performance_timing
-    performance_memory
+# Hierarchical Verbosity (Sub-specifiers)
+
+When a verbosity specifier needs to carry a nested verbosity (e.g. an ODE
+solver verbosity that also configures a linear-solve verbosity), use a
+`sub_specifiers` block. Each declared sub-specifier becomes a free type
+parameter on the generated struct, so the field stays concretely typed at the
+instance level — preserving inference when the sub-spec is forwarded to a
+downstream API.
+
+```julia
+@verbosity_specifier DEVerbosity begin
+    toggles        = (:dt_select, :step_rejected)
+    sub_specifiers = (:linear_verbosity,)
+
+    presets = (
+        Standard = (
+            dt_select        = InfoLevel(),
+            step_rejected    = WarnLevel(),
+            linear_verbosity = Standard(),  # preset value, deferred to the
+                                            # downstream package, OR a
+                                            # concrete sub-spec instance
+        ),
+        # ...
+    )
+
+    groups = ()
+end
+```
+
+A sub-specifier field accepts either an `AbstractVerbositySpecifier` instance
+or an `AbstractVerbosityPreset` singleton.
+
+# Manual Implementation
+
+If you need full control over the struct layout, you can define the parametric
+struct yourself. Subtype `AbstractVerbositySpecifier{Enabled}` and use concrete
+`MessageLevel` field types for inference:
+
+```julia
+using SciMLLogging
+using SciMLLogging: AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel
+
+struct MyAppVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    solver_iterations::MessageLevel
+    solver_convergence::MessageLevel
+    performance_timing::MessageLevel
+    performance_memory::MessageLevel
 end
 
-# Constructor with defaults
+# Default kwarg constructor — produces an enabled instance
 function MyAppVerbosity(;
-        solver_iterations = InfoLevel(),
+        solver_iterations  = InfoLevel(),
         solver_convergence = WarnLevel(),
         performance_timing = Silent(),
         performance_memory = Silent()
 )
-    MyAppVerbosity(solver_iterations, solver_convergence, performance_timing, performance_memory)
+    MyAppVerbosity{true}(solver_iterations, solver_convergence, performance_timing, performance_memory)
 end
-```
 
-# Performance Recommendation
-
-For better performance, it's recommended to use `@concrete` from ConcreteStructs.jl when defining your verbosity types. This eliminates type instabilities and improves runtime performance:
-
-```julia
-using ConcreteStructs: @concrete
-
-@concrete struct FastVerbosity <: AbstractVerbositySpecifier
-    category1
-    category2
+# Preset constructor — None() returns {false} for the compile-time short-circuit
+function MyAppVerbosity(::SciMLLogging.None)
+    MyAppVerbosity{false}(Silent(), Silent(), Silent(), Silent())
 end
 ```
 
 # Integration with Julia's Logging System
-SciMLLogging integrates with Julia's built-in logging system. You can customize how logs are handled with the SciMLLogger,
-which allows you to direct logs to different outputs. Or you can use your own logger based on the Julia logging system or LoggingExtras.jl.
+
+SciMLLogging integrates with Julia's built-in logging system. You can customize
+how logs are handled with `SciMLLogger`, which directs logs to different
+outputs, or use your own logger based on the Julia logging system or
+LoggingExtras.jl.
 
 ```julia
 # Create a logger that sends warnings to a file
@@ -128,18 +182,23 @@ with_logger(logger) do
 end
 ```
 
-Disabling Verbosity
-To disable specific message categories:
+# Disabling Verbosity
+
+To disable specific message categories, set them to `Silent()`. To disable an
+entire specifier (with zero runtime cost via the `{Enabled}` short-circuit),
+construct it with the `None()` preset:
 
 ```julia
-# Create verbosity with silent categories
-silent = MyVerbosity(
-    algorithm_choice = Silent(),
+# Per-toggle silencing — emits nothing for these toggles, but the rest still emit
+quiet = MyVerbosity(
+    algorithm_choice   = Silent(),
     iteration_progress = Silent()
 )
 
-# This won't produce any output
-@SciMLMessage("This message won't be shown", silent, :algorithm_choice)
+# Whole-specifier disable — compile-time short-circuit at every call site
+off = MyVerbosity(None())
+
+@SciMLMessage("This message won't be shown", off, :algorithm_choice)
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ using SciMLLogging
 
     presets = (
         None = (
-            algorithm_choice   = Silent(),
-            iteration_progress = Silent(),
+            algorithm_choice   = Silent,
+            iteration_progress = Silent,
         ),
         Standard = (
-            algorithm_choice   = WarnLevel(),
-            iteration_progress = InfoLevel(),
+            algorithm_choice   = WarnLevel,
+            iteration_progress = InfoLevel,
         ),
         All = (
-            algorithm_choice   = InfoLevel(),
-            iteration_progress = InfoLevel(),
+            algorithm_choice   = InfoLevel,
+            iteration_progress = InfoLevel,
         ),
     )
 
@@ -53,7 +53,7 @@ verbose = MyVerbosity()
 verbose = MyVerbosity(Standard())
 
 # Or override individual toggles
-verbose = MyVerbosity(algorithm_choice = ErrorLevel())
+verbose = MyVerbosity(algorithm_choice = ErrorLevel)
 
 # Log messages at different levels
 @SciMLMessage("Selected algorithm: GMRES", verbose, :algorithm_choice)
@@ -74,11 +74,11 @@ end
 SciMLLogging defines a single concrete `MessageLevel` type with the following
 standard severities:
 
-  - `Silent()`: No output
-  - `DebugLevel()`: Debug messages
-  - `InfoLevel()`: Informational messages
-  - `WarnLevel()`: Warning messages
-  - `ErrorLevel()`: Error messages
+  - `Silent`: No output
+  - `DebugLevel`: Debug messages
+  - `InfoLevel`: Informational messages
+  - `WarnLevel`: Warning messages
+  - `ErrorLevel`: Error messages
   - `CustomLevel(n)`: Custom level with integer value `n`
 
 # Verbosity Presets
@@ -110,8 +110,8 @@ downstream API.
 
     presets = (
         Standard = (
-            dt_select        = InfoLevel(),
-            step_rejected    = WarnLevel(),
+            dt_select        = InfoLevel,
+            step_rejected    = WarnLevel,
             linear_verbosity = Standard(),  # preset value, deferred to the
                                             # downstream package, OR a
                                             # concrete sub-spec instance
@@ -145,17 +145,17 @@ end
 
 # Default kwarg constructor — produces an enabled instance
 function MyAppVerbosity(;
-        solver_iterations  = InfoLevel(),
-        solver_convergence = WarnLevel(),
-        performance_timing = Silent(),
-        performance_memory = Silent()
+        solver_iterations  = InfoLevel,
+        solver_convergence = WarnLevel,
+        performance_timing = Silent,
+        performance_memory = Silent
 )
     MyAppVerbosity{true}(solver_iterations, solver_convergence, performance_timing, performance_memory)
 end
 
 # Preset constructor — None() returns {false} for the compile-time short-circuit
 function MyAppVerbosity(::SciMLLogging.None)
-    MyAppVerbosity{false}(Silent(), Silent(), Silent(), Silent())
+    MyAppVerbosity{false}(Silent, Silent, Silent, Silent)
 end
 ```
 
@@ -184,15 +184,15 @@ end
 
 # Disabling Verbosity
 
-To disable specific message categories, set them to `Silent()`. To disable an
+To disable specific message categories, set them to `Silent`. To disable an
 entire specifier (with zero runtime cost via the `{Enabled}` short-circuit),
 construct it with the `None()` preset:
 
 ```julia
 # Per-toggle silencing — emits nothing for these toggles, but the rest still emit
 quiet = MyVerbosity(
-    algorithm_choice   = Silent(),
-    iteration_progress = Silent()
+    algorithm_choice   = Silent,
+    iteration_progress = Silent
 )
 
 # Whole-specifier disable — compile-time short-circuit at every call site

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 [compat]
 ConcreteStructs = "0.2.3"
 Documenter = "1"
-SciMLLogging = "1.7.1"
+SciMLLogging = "2.0.0"

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -6,7 +6,7 @@ This guide will help you get up and running with SciMLLogging.jl quickly. SciMLL
 
 SciMLLogging.jl is built around three core concepts:
 
-1. **Message Levels**: Define the importance of messages (`Silent()`, `InfoLevel()`, `WarnLevel()`, `ErrorLevel()`)
+1. **Message Levels**: Define the importance of messages (`Silent`, `InfoLevel`, `WarnLevel`, `ErrorLevel`)
 2. **Verbosity Specifiers**: Control which categories of messages are shown and at what level
 3. **Verbosity Presets**: Predefined settings for common use cases (`None()`, `Minimal()`, `Standard()`, `Detailed()`, `All()`)
 
@@ -34,21 +34,21 @@ For more control, packages typically allow you to configure individual message c
 ```julia
 # Custom configuration
 custom_verbose = MyPackageVerbosity(
-    startup = InfoLevel(),      # Show startup messages
-    progress = Silent(),        # Hide progress updates
-    diagnostics = WarnLevel(),  # Show diagnostic warnings
-    performance = InfoLevel()   # Show performance info
+    startup = InfoLevel,      # Show startup messages
+    progress = Silent,        # Hide progress updates
+    diagnostics = WarnLevel,  # Show diagnostic warnings
+    performance = InfoLevel   # Show performance info
 )
 
 result = solve(problem, verbose = custom_verbose)
 ```
 
 **Message Levels:**
-- `Silent()`: No output for this category
-- `DebugLevel()`: Lowest priority messages
-- `InfoLevel()`: Informational messages
-- `WarnLevel()`: Warning messages
-- `ErrorLevel()`: Error messages
+- `Silent`: No output for this category
+- `DebugLevel`: Lowest priority messages
+- `InfoLevel`: Informational messages
+- `WarnLevel`: Warning messages
+- `ErrorLevel`: Error messages
 - `CustomLevel(n)`: Custom level with integer value
 
 ## Logging Backends

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -49,7 +49,7 @@ result = solve(problem, verbose = custom_verbose)
 - `InfoLevel`: Informational messages
 - `WarnLevel`: Warning messages
 - `ErrorLevel`: Error messages
-- `CustomLevel(n)`: Custom level with integer value
+- `MessageLevel(n)`: Custom level with integer value
 
 ## Logging Backends
 

--- a/docs/src/manual/message_levels.md
+++ b/docs/src/manual/message_levels.md
@@ -7,8 +7,8 @@ Message levels in SciMLLogging determine the severity and importance of log mess
 SciMLLogging defines a single concrete `MessageLevel` type (backed by an
 integer) that represents the severity of a log message. Standard severities are
 exposed as constants (`Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`,
-`ErrorLevel`); custom severities can be constructed via `CustomLevel(n)` (an
-alias for `MessageLevel(n)`).
+`ErrorLevel`); custom severities can be constructed by calling
+`MessageLevel(n)` directly with any integer.
 
 ```@docs
 MessageLevel
@@ -58,11 +58,8 @@ ErrorLevel
 
 ## Custom Message Levels
 
-```@docs
-CustomLevel
-```
-
-Custom levels provide flexibility for specialized use cases where the standard Info/Warn/Error hierarchy isn't sufficient.
+For specialized use cases, you can construct a `MessageLevel` directly with any
+integer. This provides flexibility beyond the standard Info/Warn/Error hierarchy.
 
 ## Usage Examples
 
@@ -77,8 +74,8 @@ error_level = ErrorLevel
 silent_level = Silent
 
 # Custom levels for specialized needs
-trace_level = CustomLevel(-500)     # Low priority debugging
-critical_level = CustomLevel(2000)  # Higher than standard error level
+trace_level = MessageLevel(-500)     # Low priority debugging
+critical_level = MessageLevel(2000)  # Higher than standard error level
 ```
 
 ## Level Hierarchy
@@ -89,6 +86,6 @@ The message levels have a natural hierarchy that affects logging behavior:
 - `InfoLevel`: Low priority for general information
 - `WarnLevel`: Medium priority
 - `ErrorLevel`: Highest standard priority
-- `CustomLevel(n)`: Priority determined by integer value `n`
+- `MessageLevel(n)`: Priority determined by integer value `n`
 
 Higher priority messages are more likely to be displayed by logging systems, while lower priority messages may be filtered out depending on the logger configuration.

--- a/docs/src/manual/message_levels.md
+++ b/docs/src/manual/message_levels.md
@@ -7,10 +7,10 @@ Message levels in SciMLLogging determine the severity and importance of log mess
 SciMLLogging provides a hierarchy of message levels that correspond to different types of information:
 
 ```@docs
-AbstractMessageLevel
+MessageLevel
 ```
 
-Each of the `AbstractMessageLevel`s correspond to a Julia Logging `LogLevel` type with an associated integer, besides `Silent`. 
+`AbstractMessageLevel` is a backward-compatible alias for `MessageLevel`. Each level (apart from `Silent`) corresponds to a Julia Logging `LogLevel` type with an associated integer.
 See the [Julia Logging documentation](https://docs.julialang.org/en/v1/stdlib/Logging/#Log-event-structure) for more details. 
 
 ## Standard Message Levels

--- a/docs/src/manual/message_levels.md
+++ b/docs/src/manual/message_levels.md
@@ -4,14 +4,19 @@ Message levels in SciMLLogging determine the severity and importance of log mess
 
 ## Overview
 
-SciMLLogging provides a hierarchy of message levels that correspond to different types of information:
+SciMLLogging defines a single concrete `MessageLevel` type (backed by an
+integer) that represents the severity of a log message. Standard severities are
+exposed as constants (`Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`,
+`ErrorLevel`); custom severities can be constructed via `CustomLevel(n)` (an
+alias for `MessageLevel(n)`).
 
 ```@docs
 MessageLevel
 ```
 
-`AbstractMessageLevel` is a backward-compatible alias for `MessageLevel`. Each level (apart from `Silent`) corresponds to a Julia Logging `LogLevel` type with an associated integer.
-See the [Julia Logging documentation](https://docs.julialang.org/en/v1/stdlib/Logging/#Log-event-structure) for more details. 
+Each level apart from `Silent` corresponds to a Julia Logging `LogLevel` with
+an associated integer. See the [Julia Logging documentation](https://docs.julialang.org/en/v1/stdlib/Logging/#Log-event-structure)
+for more details. 
 
 ## Standard Message Levels
 

--- a/docs/src/manual/message_levels.md
+++ b/docs/src/manual/message_levels.md
@@ -31,7 +31,7 @@ The `Silent` level is special - it completely suppresses output for a message. A
 ```@docs
 DebugLevel
 ```
-`DebugLevel()` is for messages with a very low priority. 
+`DebugLevel` is for messages with a very low priority. 
 By default, these messages are not logged at all, and the `JULIA_DEBUG` environment variable needs to be set.
 For details see the [Julia Logging documentation](https://docs.julialang.org/en/v1/stdlib/Logging/#Environment-variables). 
 
@@ -40,21 +40,21 @@ For details see the [Julia Logging documentation](https://docs.julialang.org/en/
 InfoLevel
 ```
 
-Use `InfoLevel()` for general status updates, progress information, and routine diagnostic messages that users might want to see during normal operation.
+Use `InfoLevel` for general status updates, progress information, and routine diagnostic messages that users might want to see during normal operation.
 
 ### Warning Level
 ```@docs
 WarnLevel
 ```
 
-`WarnLevel()` should be used for potentially problematic situations that don't prevent execution but may require user attention.
+`WarnLevel` should be used for potentially problematic situations that don't prevent execution but may require user attention.
 
 ### Error Level
 ```@docs
 ErrorLevel
 ```
 
-`ErrorLevel()` is reserved for serious problems and failures that indicate something has gone wrong in the computation.
+`ErrorLevel` is reserved for serious problems and failures that indicate something has gone wrong in the computation.
 
 ## Custom Message Levels
 
@@ -70,11 +70,11 @@ Custom levels provide flexibility for specialized use cases where the standard I
 using SciMLLogging
 
 # Standard levels
-debug_level = DebugLevel()
-info_level = InfoLevel()
-warn_level = WarnLevel()
-error_level = ErrorLevel()
-silent_level = Silent()
+debug_level = DebugLevel
+info_level = InfoLevel
+warn_level = WarnLevel
+error_level = ErrorLevel
+silent_level = Silent
 
 # Custom levels for specialized needs
 trace_level = CustomLevel(-500)     # Low priority debugging
@@ -84,11 +84,11 @@ critical_level = CustomLevel(2000)  # Higher than standard error level
 ## Level Hierarchy
 
 The message levels have a natural hierarchy that affects logging behavior:
-- `Silent()`: No output (always suppressed)
-- `DebugLevel()`: Lowest priority message
-- `InfoLevel()`: Low priority for general information
-- `WarnLevel()`: Medium priority
-- `ErrorLevel()`: Highest standard priority
+- `Silent`: No output (always suppressed)
+- `DebugLevel`: Lowest priority message
+- `InfoLevel`: Low priority for general information
+- `WarnLevel`: Medium priority
+- `ErrorLevel`: Highest standard priority
 - `CustomLevel(n)`: Priority determined by integer value `n`
 
 Higher priority messages are more likely to be displayed by logging systems, while lower priority messages may be filtered out depending on the logger configuration.

--- a/docs/src/manual/presets.md
+++ b/docs/src/manual/presets.md
@@ -61,19 +61,43 @@ All
 
 ## Custom Presets
 
-Packages can define their own preset types for specialized use cases:
+Packages can define their own preset types for specialized use cases. With the
+`@verbosity_specifier` macro, simply add the custom preset as a key in the
+`presets` block — the macro generates the preset's struct definition and the
+matching constructor automatically:
 
 ```julia
-# Package-specific preset
+@verbosity_specifier MyPackageVerbosity begin
+    toggles = (:initialization, :progress, :convergence, :warnings, :errors)
+
+    presets = (
+        # ... standard presets ...
+        DebuggingPreset = (
+            initialization = InfoLevel(),
+            progress       = DebugLevel(),  # Extra detailed progress
+            convergence    = InfoLevel(),
+            warnings       = WarnLevel(),
+            errors         = ErrorLevel(),
+        ),
+    )
+
+    groups = ()
+end
+```
+
+For a manually-defined specifier, declare the preset type and the constructor
+yourself:
+
+```julia
 struct DebuggingPreset <: AbstractVerbosityPreset end
 
 function MyPackageVerbosity(::DebuggingPreset)
-    MyPackageVerbosity{true}(
+    MyPackageVerbosity(
         initialization = InfoLevel(),
-        progress = DebugLevel(),  # Extra detailed progress
-        convergence = InfoLevel(),
-        warnings = WarnLevel(),
-        errors = ErrorLevel()
+        progress       = DebugLevel(),
+        convergence    = InfoLevel(),
+        warnings       = WarnLevel(),
+        errors         = ErrorLevel(),
     )
 end
 ```

--- a/docs/src/manual/presets.md
+++ b/docs/src/manual/presets.md
@@ -73,11 +73,11 @@ matching constructor automatically:
     presets = (
         # ... standard presets ...
         DebuggingPreset = (
-            initialization = InfoLevel(),
-            progress       = DebugLevel(),  # Extra detailed progress
-            convergence    = InfoLevel(),
-            warnings       = WarnLevel(),
-            errors         = ErrorLevel(),
+            initialization = InfoLevel,
+            progress       = DebugLevel,  # Extra detailed progress
+            convergence    = InfoLevel,
+            warnings       = WarnLevel,
+            errors         = ErrorLevel,
         ),
     )
 
@@ -93,11 +93,11 @@ struct DebuggingPreset <: AbstractVerbosityPreset end
 
 function MyPackageVerbosity(::DebuggingPreset)
     MyPackageVerbosity(
-        initialization = InfoLevel(),
-        progress       = DebugLevel(),
-        convergence    = InfoLevel(),
-        warnings       = WarnLevel(),
-        errors         = ErrorLevel(),
+        initialization = InfoLevel,
+        progress       = DebugLevel,
+        convergence    = InfoLevel,
+        warnings       = WarnLevel,
+        errors         = ErrorLevel,
     )
 end
 ```
@@ -125,11 +125,11 @@ verbosity = SolverVerbosity(Standard())
 
 # ...might be equivalent to this manual configuration:
 verbosity = SolverVerbosity(
-    initialization = InfoLevel(),
-    progress = Silent(),
-    convergence = InfoLevel(),
-    diagnostics = WarnLevel(),
-    performance = InfoLevel()
+    initialization = InfoLevel,
+    progress = Silent,
+    convergence = InfoLevel,
+    diagnostics = WarnLevel,
+    performance = InfoLevel
 )
 ```
 

--- a/docs/src/manual/verbosity_specifiers.md
+++ b/docs/src/manual/verbosity_specifiers.md
@@ -50,11 +50,11 @@ Each field in a verbosity specifier can be set to any `MessageLevel`:
 ```julia
 # Create a custom configuration
 custom_verbosity = MyPackageVerbosity(
-    initialization = InfoLevel(),     # Show startup information
-    progress = Silent(),             # Hide progress updates
-    convergence = InfoLevel(),        # Show convergence status
-    diagnostics = WarnLevel(),       # Show diagnostic messages
-    performance = InfoLevel()        # Show performance info
+    initialization = InfoLevel,     # Show startup information
+    progress = Silent,             # Hide progress updates
+    convergence = InfoLevel,        # Show convergence status
+    diagnostics = WarnLevel,       # Show diagnostic messages
+    performance = InfoLevel        # Show performance info
 )
 ```
 

--- a/docs/src/manual/verbosity_specifiers.md
+++ b/docs/src/manual/verbosity_specifiers.md
@@ -22,27 +22,26 @@ The `@verbosity_specifier` macro automatically generates a parametric struct wit
 
 ### Manual Implementation
 
-Alternatively, you can manually define verbosity specifier types by subtyping `AbstractVerbositySpecifier`:
+Alternatively, you can manually define verbosity specifier types by subtyping
+`AbstractVerbositySpecifier{Enabled}`. The `Enabled` type parameter lets the compiler
+eliminate logging branches entirely when the specifier is disabled:
 
 ```julia
 using SciMLLogging
-using ConcreteStructs: @concrete
 
-@concrete struct MyPackageVerbosity <: AbstractVerbositySpecifier
-    initialization   # Controls startup and setup messages
-    progress         # Controls progress and iteration updates
-    convergence      # Controls convergence-related messages
-    diagnostics      # Controls diagnostic messages
-    performance      # Controls performance-related messages
+struct MyPackageVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    initialization::MessageLevel   # Controls startup and setup messages
+    progress::MessageLevel         # Controls progress and iteration updates
+    convergence::MessageLevel      # Controls convergence-related messages
+    diagnostics::MessageLevel      # Controls diagnostic messages
+    performance::MessageLevel      # Controls performance-related messages
 end
 ```
 
-**Note:** It is recommended that the verbosity specifier is concretely typed for several performance reasons:
+**Note:** Concretely typing the fields as `MessageLevel` is recommended for performance:
 
 - **Type stability**: Eliminates type instabilities that can hurt performance
-- **Compile-time optimization**: Allows the compiler to generate more efficient code
-
-The `@concrete` macro from ConcreteStructs.jl is a convenient way to automate that. 
+- **Compile-time optimization**: Allows the compiler to constant-fold logging branches when the specifier is a constant
 
 ## Configuring Message Categories
 

--- a/docs/src/manual/verbosity_specifiers.md
+++ b/docs/src/manual/verbosity_specifiers.md
@@ -45,7 +45,7 @@ end
 
 ## Configuring Message Categories
 
-Each field in a verbosity specifier can be set to any `AbstractMessageLevel`:
+Each field in a verbosity specifier can be set to any `MessageLevel`:
 
 ```julia
 # Create a custom configuration

--- a/docs/src/tutorials/developer_tutorial.md
+++ b/docs/src/tutorials/developer_tutorial.md
@@ -53,25 +53,25 @@ using SciMLLogging
 
     presets = (
         None = (
-            initialization   = Silent(),
-            iterations       = Silent(),
-            convergence      = Silent(),
-            warnings         = Silent(),
+            initialization   = Silent,
+            iterations       = Silent,
+            convergence      = Silent,
+            warnings         = Silent,
             linear_verbosity = None(),
         ),
         Standard = (
-            initialization   = InfoLevel(),
-            iterations       = Silent(),
-            convergence      = InfoLevel(),
-            warnings         = WarnLevel(),
+            initialization   = InfoLevel,
+            iterations       = Silent,
+            convergence      = InfoLevel,
+            warnings         = WarnLevel,
             linear_verbosity = Standard(),  # preset value, deferred to
                                             # the downstream package
         ),
         All = (
-            initialization   = InfoLevel(),
-            iterations       = InfoLevel(),
-            convergence      = InfoLevel(),
-            warnings         = WarnLevel(),
+            initialization   = InfoLevel,
+            iterations       = InfoLevel,
+            convergence      = InfoLevel,
+            warnings         = WarnLevel,
             linear_verbosity = All(),
         ),
     )
@@ -119,10 +119,10 @@ end
 
 # Constructor with defaults — produces an enabled instance
 function MySolverVerbosity(;
-        initialization = InfoLevel(),
-        iterations = Silent(),
-        convergence = InfoLevel(),
-        warnings = WarnLevel()
+        initialization = InfoLevel,
+        iterations = Silent,
+        convergence = InfoLevel,
+        warnings = WarnLevel
 )
     MySolverVerbosity{true}(initialization, iterations, convergence, warnings)
 end
@@ -144,11 +144,11 @@ configurations:
 # the type parameter signals "disabled" so logging calls compile away.
 function MySolverVerbosity(preset::AbstractVerbosityPreset)
     if preset isa None
-        MySolverVerbosity{false}(Silent(), Silent(), Silent(), Silent())
+        MySolverVerbosity{false}(Silent, Silent, Silent, Silent)
     elseif preset isa All
-        MySolverVerbosity{true}(InfoLevel(), InfoLevel(), InfoLevel(), WarnLevel())
+        MySolverVerbosity{true}(InfoLevel, InfoLevel, InfoLevel, WarnLevel)
     elseif preset isa Minimal
-        MySolverVerbosity{true}(Silent(), Silent(), ErrorLevel(), ErrorLevel())
+        MySolverVerbosity{true}(Silent, Silent, ErrorLevel, ErrorLevel)
     else
         MySolverVerbosity()  # Default
     end
@@ -197,10 +197,10 @@ Provide clear documentation for your users:
 Controls verbosity output from MySolver functions.
 
 # Keyword Arguments
-- `initialization = InfoLevel()`: Messages about solver setup
-- `iterations = Silent()`: Per-iteration progress messages
-- `convergence = InfoLevel()`: Convergence/failure notifications
-- `error_control = WarnLevel()`: Messages about solver error control
+- `initialization = InfoLevel`: Messages about solver setup
+- `iterations = Silent`: Per-iteration progress messages
+- `convergence = InfoLevel`: Convergence/failure notifications
+- `error_control = WarnLevel`: Messages about solver error control
 
 # Constructors
 - `MySolverVerbosity()`: Default enabled verbosity
@@ -214,14 +214,14 @@ Controls verbosity output from MySolver functions.
 verbose = MySolverVerbosity()
 
 # Custom verbosity - show everything except iterations
-verbose = MySolverVerbosity(iterations = Silent())
+verbose = MySolverVerbosity(iterations = Silent)
 
 # Silent mode
 verbose = MySolverVerbosity(
-    initialization = Silent(),
-    iterations = Silent(),
-    convergence = Silent(),
-    warnings = Silent()
+    initialization = Silent,
+    iterations = Silent,
+    convergence = Silent,
+    warnings = Silent
 )
 ```
 """
@@ -240,7 +240,7 @@ struct ExampleVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
 end
 
 # Constructor with default — produces an enabled instance
-ExampleVerbosity(; progress = InfoLevel()) = ExampleVerbosity{true}(progress)
+ExampleVerbosity(; progress = InfoLevel) = ExampleVerbosity{true}(progress)
 
 function solve_example(n::Int, verbose::ExampleVerbosity)
     result = 0

--- a/docs/src/tutorials/developer_tutorial.md
+++ b/docs/src/tutorials/developer_tutorial.md
@@ -8,7 +8,7 @@ SciMLLogging.jl provides four main components for package developers:
 
 1. `AbstractVerbositySpecifier` - Base type for creating custom verbosity types
 2. `@SciMLMessage` - Macro for emitting conditional log messages
-3.  Log levels - Predefined log levels (`Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`, `ErrorLevel`, `CustomLevel(n)`). These are the fields of the `AbstractVerbositySpecifier`s that determine which messages get logged, and at what log level. 
+3.  Log levels - Predefined log levels (`Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`, `ErrorLevel`, or `MessageLevel(n)` for a custom integer). These are the fields of the `AbstractVerbositySpecifier`s that determine which messages get logged, and at what log level. 
 4.  Verbosity preset levels - `None`, `Minimal`, `Standard`, `Detailed`, `All`. These represent predefined sets of log levels. 
 
 ### AbstractVerbositySpecifier

--- a/docs/src/tutorials/developer_tutorial.md
+++ b/docs/src/tutorials/developer_tutorial.md
@@ -28,30 +28,32 @@ First, decide what aspects of your package should be controllable by users. For 
 
 ## Step 2: Create Your Verbosity Type
 
-Define a struct that subtypes `AbstractVerbositySpecifier`:
+Define a parametric struct that subtypes `AbstractVerbositySpecifier{Enabled}`. The
+`Enabled` parameter lets the compiler eliminate logging branches entirely when the
+verbosity instance is disabled (`Enabled === false`):
 
 ```julia
 using SciMLLogging
-using ConcreteStructs: @concrete
 
-@concrete struct MySolverVerbosity <: AbstractVerbositySpecifier
-    initialization
-    iterations
-    convergence
-    warnings
+struct MySolverVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    initialization::MessageLevel
+    iterations::MessageLevel
+    convergence::MessageLevel
+    warnings::MessageLevel
 end
 
-# Constructor with defaults
+# Constructor with defaults — produces an enabled instance
 function MySolverVerbosity(;
         initialization = InfoLevel(),
         iterations = Silent(),
         convergence = InfoLevel(),
         warnings = WarnLevel()
 )
-    MySolverVerbosity(initialization, iterations, convergence, warnings)
+    MySolverVerbosity{true}(initialization, iterations, convergence, warnings)
 end
 ```
-- Use `@concrete` from ConcreteStructs.jl for better performance
+- Concretely typing fields as `MessageLevel` lets the compiler constant-fold logging branches
+- The `{Enabled}` type parameter selects between two `get_message_level` methods at compile time
 - Each field represents a category of messages your package can emit
 
 ## Step 3: Add Convenience Constructors
@@ -59,29 +61,15 @@ end
 Make it easy for users to create verbosity instances. Perhaps include a constructor that can take a AbstractVerbosityPreset, and use it to set the rest of the fields, and a constructor that takes all keyword arguments:
 
 ```julia
-# Preset-based constructor (optional)
+# Preset-based constructor (optional). Note that `None()` returns a {false}
+# instance — the type parameter signals "disabled" so logging calls compile away.
 function MySolverVerbosity(preset::AbstractVerbosityPreset)
     if preset isa None
-        MySolverVerbosity(
-            initialization = Silent(),
-            iterations = Silent(),
-            convergence = Silent(),
-            warnings = Silent()
-        )
+        MySolverVerbosity{false}(Silent(), Silent(), Silent(), Silent())
     elseif preset isa All
-        MySolverVerbosity(
-            initialization = InfoLevel(),
-            iterations = InfoLevel(),
-            convergence = InfoLevel(),
-            error_control = WarnLevel()
-        )
+        MySolverVerbosity{true}(InfoLevel(), InfoLevel(), InfoLevel(), WarnLevel())
     elseif preset isa Minimal
-        MySolverVerbosity(
-            initialization = Silent(),
-            iterations = Silent(),
-            convergence = ErrorLevel(),
-            error_control = ErrorLevel()
-        )
+        MySolverVerbosity{true}(Silent(), Silent(), ErrorLevel(), ErrorLevel())
     else
         MySolverVerbosity()  # Default
     end
@@ -164,17 +152,16 @@ verbose = MySolverVerbosity(
 
 Here's a complete minimal example:
 
-```@example 
+```@example
 using SciMLLogging
-using ConcreteStructs: @concrete
-import SciMLLogging: AbstractVerbositySpecifier
+import SciMLLogging: AbstractVerbositySpecifier, MessageLevel
 
-@concrete struct ExampleVerbosity <: AbstractVerbositySpecifier
-    progress
+struct ExampleVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    progress::MessageLevel
 end
 
-# Constructor with default
-ExampleVerbosity(; progress = InfoLevel()) = ExampleVerbosity(progress)
+# Constructor with default — produces an enabled instance
+ExampleVerbosity(; progress = InfoLevel()) = ExampleVerbosity{true}(progress)
 
 function solve_example(n::Int, verbose::ExampleVerbosity)
     result = 0

--- a/docs/src/tutorials/developer_tutorial.md
+++ b/docs/src/tutorials/developer_tutorial.md
@@ -28,9 +28,84 @@ First, decide what aspects of your package should be controllable by users. For 
 
 ## Step 2: Create Your Verbosity Type
 
-Define a parametric struct that subtypes `AbstractVerbositySpecifier{Enabled}`. The
-`Enabled` parameter lets the compiler eliminate logging branches entirely when the
-verbosity instance is disabled (`Enabled === false`):
+There are two ways to define a verbosity specifier: the `@verbosity_specifier`
+macro (recommended for new code) or a manual struct definition (useful when you
+need full control).
+
+### Option A: Use the `@verbosity_specifier` macro
+
+The macro generates the parametric struct, all the constructors, preset
+support, group keyword arguments, and validation in one declaration:
+
+```julia
+using SciMLLogging
+
+@verbosity_specifier MySolverVerbosity begin
+    # Toggles control individual message categories. Each toggle field is
+    # typed as `MessageLevel`.
+    toggles = (:initialization, :iterations, :convergence, :warnings)
+
+    # Optional. Sub-specifier fields hold either another verbosity specifier
+    # or a verbosity preset. Use this when your spec needs to configure
+    # nested behavior — e.g., a solver verbosity that controls the verbosity
+    # of an inner linear-solve step.
+    sub_specifiers = (:linear_verbosity,)
+
+    presets = (
+        None = (
+            initialization   = Silent(),
+            iterations       = Silent(),
+            convergence      = Silent(),
+            warnings         = Silent(),
+            linear_verbosity = None(),
+        ),
+        Standard = (
+            initialization   = InfoLevel(),
+            iterations       = Silent(),
+            convergence      = InfoLevel(),
+            warnings         = WarnLevel(),
+            linear_verbosity = Standard(),  # preset value, deferred to
+                                            # the downstream package
+        ),
+        All = (
+            initialization   = InfoLevel(),
+            iterations       = InfoLevel(),
+            convergence      = InfoLevel(),
+            warnings         = WarnLevel(),
+            linear_verbosity = All(),
+        ),
+    )
+
+    # Groups let users set multiple toggles at once via a single kwarg.
+    groups = (
+        solver = (:initialization, :iterations, :convergence),
+    )
+end
+```
+
+The macro generates:
+- `MySolverVerbosity{Enabled, S1}` — parametric on `Enabled` and one type
+  parameter per sub-specifier slot.
+- A preset constructor per preset name (`MySolverVerbosity(::None)`, etc.).
+- A keyword constructor with `preset=`, group kwargs (`solver=`), and field
+  kwargs, applying precedence: individual > group > preset.
+
+When a sub-specifier field is set to a concrete sub-spec instance (e.g.
+`LinearVerbosity(Detailed())`), the outer specifier's type parameter
+specializes to that concrete type — preserving inference into downstream
+APIs that consume the sub-spec.
+
+When the field holds a preset value (e.g. `Standard()`), the type parameter
+specializes to the preset's singleton type — also concrete. Downstream code
+that drills into the field can dispatch on whether it received a preset or
+a fully-configured sub-spec.
+
+### Option B: Define the struct manually
+
+Sometimes you need full control over the struct layout (e.g. when you have
+complex constructors, additional fields, or want to integrate with another
+type system). Define a parametric struct that subtypes
+`AbstractVerbositySpecifier{Enabled}`:
 
 ```julia
 using SciMLLogging
@@ -56,13 +131,17 @@ end
 - The `{Enabled}` type parameter selects between two `get_message_level` methods at compile time
 - Each field represents a category of messages your package can emit
 
-## Step 3: Add Convenience Constructors
+## Step 3: Add Convenience Constructors (manual path only)
 
-Make it easy for users to create verbosity instances. Perhaps include a constructor that can take a AbstractVerbosityPreset, and use it to set the rest of the fields, and a constructor that takes all keyword arguments:
+If you used the macro in Step 2, the preset constructors and keyword
+constructor are already generated — skip ahead to Step 4. For a manually
+defined specifier, add a preset-based constructor that maps each preset to a
+field configuration, and let the kwarg constructor from Step 2 handle ad-hoc
+configurations:
 
 ```julia
-# Preset-based constructor (optional). Note that `None()` returns a {false}
-# instance — the type parameter signals "disabled" so logging calls compile away.
+# Preset-based constructor. Note that `None()` returns a {false} instance —
+# the type parameter signals "disabled" so logging calls compile away.
 function MySolverVerbosity(preset::AbstractVerbosityPreset)
     if preset isa None
         MySolverVerbosity{false}(Silent(), Silent(), Silent(), Silent())

--- a/docs/src/tutorials/user_tutorial.md
+++ b/docs/src/tutorials/user_tutorial.md
@@ -44,21 +44,21 @@ For more control, you can configure individual message categories:
 ```julia
 # Example: Customizing a solve's verbosity
 verbose_settings = SolverVerbosity(
-    initialization = InfoLevel(),      # Show startup messages
-    iterations = Silent(),             # Don't show each iteration
-    convergence = InfoLevel(),         # Show convergence information
-    error_control = WarnLevel()        # Show warnings related to error control of the solver
+    initialization = InfoLevel,      # Show startup messages
+    iterations = Silent,             # Don't show each iteration
+    convergence = InfoLevel,         # Show convergence information
+    error_control = WarnLevel        # Show warnings related to error control of the solver
 )
 
 result = solve(problem, verbose = verbose_settings)
 ```
 
 **Message Levels:**
-- `Silent()`: No output for this category
-- `DebugLevel()`: Lowest priority debug messages
-- `InfoLevel()`: Informational messages
-- `WarnLevel()`: Warning messages
-- `ErrorLevel()`: Error messages
+- `Silent`: No output for this category
+- `DebugLevel`: Lowest priority debug messages
+- `InfoLevel`: Informational messages
+- `WarnLevel`: Warning messages
+- `ErrorLevel`: Error messages
 - `CustomLevel(n)`: Custom level with integer value `n`
 
 ## Complete Working Example
@@ -82,26 +82,26 @@ end
 
 # Likewise the constructors would typically be implemented by a package
 function SolverVerbosity(;
-    initialization = InfoLevel(),
-    iterations = Silent(),
-    convergence = InfoLevel(),
-    linear_solve = Silent(),
-    warnings = WarnLevel()
+    initialization = InfoLevel,
+    iterations = Silent,
+    convergence = InfoLevel,
+    linear_solve = Silent,
+    warnings = WarnLevel
     )
     SolverVerbosity{true}(initialization, iterations, convergence, linear_solve, warnings)
 end
 
 # 2. Implement preset support. None() returns a {false} instance — disabled at the type level.
 function SolverVerbosity(::None)
-    SolverVerbosity{false}(Silent(), Silent(), Silent(), Silent(), Silent())
+    SolverVerbosity{false}(Silent, Silent, Silent, Silent, Silent)
 end
 
 function SolverVerbosity(::Standard)
-    SolverVerbosity{true}(InfoLevel(), Silent(), InfoLevel(), Silent(), WarnLevel())
+    SolverVerbosity{true}(InfoLevel, Silent, InfoLevel, Silent, WarnLevel)
 end
 
 function SolverVerbosity(::All)
-    SolverVerbosity{true}(InfoLevel(), InfoLevel(), InfoLevel(), InfoLevel(), WarnLevel())
+    SolverVerbosity{true}(InfoLevel, InfoLevel, InfoLevel, InfoLevel, WarnLevel)
 end
 
 # 3. Example solver function using SciMLLogging, the specific messages and where the messages are emitted
@@ -145,11 +145,11 @@ result3 = example_solver(problem, verbose = SolverVerbosity(None()))
 
 println("\n=== With custom verbosity ===")
 custom_verbose = SolverVerbosity(
-    initialization = InfoLevel(),
-    iterations = Silent(),
-    convergence = InfoLevel(),
-    linear_solve = InfoLevel(),
-    warnings = ErrorLevel()  # Treat warnings as errors for this run
+    initialization = InfoLevel,
+    iterations = Silent,
+    convergence = InfoLevel,
+    linear_solve = InfoLevel,
+    warnings = ErrorLevel  # Treat warnings as errors for this run
 )
 result4 = example_solver(problem, verbose = custom_verbose)
 ```

--- a/docs/src/tutorials/user_tutorial.md
+++ b/docs/src/tutorials/user_tutorial.md
@@ -59,7 +59,7 @@ result = solve(problem, verbose = verbose_settings)
 - `InfoLevel`: Informational messages
 - `WarnLevel`: Warning messages
 - `ErrorLevel`: Error messages
-- `CustomLevel(n)`: Custom level with integer value `n`
+- `MessageLevel(n)`: Custom level with integer value `n`
 
 ## Complete Working Example
 

--- a/docs/src/tutorials/user_tutorial.md
+++ b/docs/src/tutorials/user_tutorial.md
@@ -67,40 +67,41 @@ Here's a full example showing how SciMLLogging works in practice, using a simula
 
 ```@example
 using SciMLLogging
-using SciMLLogging: None, Standard, All
-using ConcreteStructs: @concrete
+using SciMLLogging: None, Standard, All, AbstractVerbositySpecifier, MessageLevel
 
-# 1. Define a verbosity specifier (this would typically be done by a package)
-@concrete struct SolverVerbosity <: AbstractVerbositySpecifier
-    initialization
-    iterations
-    convergence
-    linear_solve
-    warnings
+# 1. Define a verbosity specifier (this would typically be done by a package).
+#    The {Enabled} type parameter lets the compiler eliminate logging branches
+#    entirely when the specifier is disabled.
+struct SolverVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    initialization::MessageLevel
+    iterations::MessageLevel
+    convergence::MessageLevel
+    linear_solve::MessageLevel
+    warnings::MessageLevel
 end
 
 # Likewise the constructors would typically be implemented by a package
 function SolverVerbosity(;
-    initialization = Info(),
+    initialization = InfoLevel(),
     iterations = Silent(),
     convergence = InfoLevel(),
     linear_solve = Silent(),
     warnings = WarnLevel()
     )
-    SolverVerbosity(initialization, iterations, convergence, linear_solve, warnings)
+    SolverVerbosity{true}(initialization, iterations, convergence, linear_solve, warnings)
 end
 
-# 2. Implement preset support
-function SolverVerbosity(preset::None)
-    SolverVerbosity(Silent(), Silent(), Silent(), Silent(), Silent())
+# 2. Implement preset support. None() returns a {false} instance — disabled at the type level.
+function SolverVerbosity(::None)
+    SolverVerbosity{false}(Silent(), Silent(), Silent(), Silent(), Silent())
 end
 
-function SolverVerbosity(preset::Standard)
-    SolverVerbosity(InfoLevel(), Silent(), InfoLevel(), Silent(), WarnLevel())
+function SolverVerbosity(::Standard)
+    SolverVerbosity{true}(InfoLevel(), Silent(), InfoLevel(), Silent(), WarnLevel())
 end
 
-function SolverVerbosity(preset::All)
-    SolverVerbosity(InfoLevel(), InfoLevel(), InfoLevel(), InfoLevel(), WarnLevel())
+function SolverVerbosity(::All)
+    SolverVerbosity{true}(InfoLevel(), InfoLevel(), InfoLevel(), InfoLevel(), WarnLevel())
 end
 
 # 3. Example solver function using SciMLLogging, the specific messages and where the messages are emitted

--- a/ext/SciMLLoggingTracyExt.jl
+++ b/ext/SciMLLoggingTracyExt.jl
@@ -1,28 +1,22 @@
 module SciMLLoggingTracyExt
 
 using SciMLLogging
+using SciMLLogging: MessageLevel, DebugLevel, InfoLevel, WarnLevel, ErrorLevel
 using Tracy
-import Logging
 
-# Map log levels to Tracy color symbols
-function level_to_color(level)
-    if level == Logging.Debug
-        return :cyan
-    elseif level == Logging.Info
-        return :green
-    elseif level == Logging.Warn
-        return :yellow
-    elseif level == Logging.Error
-        return :red
-    else
-        return :white  # Default for custom levels
-    end
+# Map MessageLevel values to Tracy color symbols
+function level_to_color(level::MessageLevel)
+    level == DebugLevel && return :cyan
+    level == InfoLevel  && return :green
+    level == WarnLevel  && return :yellow
+    level == ErrorLevel && return :red
+    return :white  # Default for custom MessageLevel values
 end
 
 # Override the fallback implementation when Tracy is loaded
-function SciMLLogging.emit_tracy_message(msg, level, _file, _line, __module)
-    # Use Tracy.jl's tracymsg to emit the message with color based on log level
-    # The message will show up in the Tracy profiler with appropriate color
+function SciMLLogging.emit_tracy_message(msg, level::MessageLevel, _, _, _)
+    # Use Tracy.jl's tracymsg to emit the message with color based on level.
+    # The message will show up in the Tracy profiler with appropriate color.
     color = level_to_color(level)
     return Tracy.tracymsg(msg; color)
 end

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -10,7 +10,7 @@ include("utils.jl")
 include("verbspec_generation_macro.jl")
 
 # Export public API
-export AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel, AbstractMessageLevel
+export AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel
 export DebugLevel, InfoLevel, WarnLevel, ErrorLevel, CustomLevel, Silent
 export @SciMLMessage
 export verbosity_to_int, verbosity_to_bool

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -10,7 +10,7 @@ include("utils.jl")
 include("verbspec_generation_macro.jl")
 
 # Export public API
-export AbstractVerbositySpecifier, AbstractVerbosityPreset, AbstractMessageLevel
+export AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel, AbstractMessageLevel
 export DebugLevel, InfoLevel, WarnLevel, ErrorLevel, CustomLevel, Silent
 export @SciMLMessage
 export verbosity_to_int, verbosity_to_bool

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -11,7 +11,7 @@ include("verbspec_generation_macro.jl")
 
 # Export public API
 export AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel
-export DebugLevel, InfoLevel, WarnLevel, ErrorLevel, CustomLevel, Silent
+export DebugLevel, InfoLevel, WarnLevel, ErrorLevel, Silent
 export @SciMLMessage
 export verbosity_to_int, verbosity_to_bool
 export SciMLLogger

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -121,7 +121,7 @@ To emit a simple string, `@SciMLMessage("message", verbosity, :option)` will emi
 
 `@SciMLMessage` can also be used to emit a log message coming from the evaluation of a 0-argument function. This function is resolved in the environment of the macro call.
 Therefore it can use variables from the surrounding environment. This may be useful if the log message writer wishes to carry out some calculations using existing variables
-and use them in the log message. The function is only called if the message category is not `Silent()`, avoiding unnecessary computation.
+and use them in the log message. The function is only called if the message category is not `Silent`, avoiding unnecessary computation.
 
 The macro works with any `AbstractVerbositySpecifier` implementation:
 
@@ -159,8 +159,8 @@ end
 Alternatively, the macro also accepts a boolean value for `verb`:
 
 When `verb` is a boolean:
-- `true` will emit the message at `WarnLevel()`
-- `false` will suppress the message (equivalent to `Silent()`)
+- `true` will emit the message at `WarnLevel`
+- `false` will suppress the message (equivalent to `Silent`)
 
 The two-argument form `@SciMLMessage(message, verbosity)` can be used when `verbosity` is a `Bool`:
 
@@ -239,11 +239,11 @@ end
 
     # Standard levels
 
-    verbosity_to_int(Silent())        # Returns 0
-    verbosity_to_int(DebugLevel())    # Returns 1
-    verbosity_to_int(InfoLevel())     # Returns 2
-    verbosity_to_int(WarnLevel())     # Returns 3
-    verbosity_to_int(ErrorLevel())    # Returns 4
+    verbosity_to_int(Silent)        # Returns 0
+    verbosity_to_int(DebugLevel)    # Returns 1
+    verbosity_to_int(InfoLevel)     # Returns 2
+    verbosity_to_int(WarnLevel)     # Returns 3
+    verbosity_to_int(ErrorLevel)    # Returns 4
 
     # Custom levels
 
@@ -272,12 +272,12 @@ end
     using SciMLLogging
 
     # Silent returns false
-    verbosity_to_bool(Silent())        # Returns false
+    verbosity_to_bool(Silent)        # Returns false
 
     # All other levels return true
-    verbosity_to_bool(InfoLevel())     # Returns true
-    verbosity_to_bool(WarnLevel())     # Returns true
-    verbosity_to_bool(ErrorLevel())    # Returns true
+    verbosity_to_bool(InfoLevel)     # Returns true
+    verbosity_to_bool(WarnLevel)     # Returns true
+    verbosity_to_bool(ErrorLevel)    # Returns true
     verbosity_to_bool(CustomLevel(5))  # Returns true
     ```
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -226,9 +226,9 @@ macro SciMLMessage(f_or_message, verb)
 end
 
 """
-        `verbosity_to_int(verb::AbstractMessageLevel)`
+        `verbosity_to_int(verb::MessageLevel)`
 
-    Takes a `AbstractMessageLevel` and gives a corresponding integer value.
+    Takes a `MessageLevel` and gives a corresponding integer value.
     Verbosity settings that use integers or enums that hold integers are relatively common.
     This provides an interface so that these packages can be used with SciMLVerbosity. Each of the basic verbosity levels
     are mapped to an integer.
@@ -261,9 +261,9 @@ function verbosity_to_int(verb::MessageLevel)
 end
 
 """
-        `verbosity_to_bool(verb::AbstractMessageLevel)`
-        
-    Takes a `AbstractMessageLevel` and gives a corresponding boolean value.
+        `verbosity_to_bool(verb::MessageLevel)`
+
+    Takes a `MessageLevel` and gives a corresponding boolean value.
     Verbosity settings that use booleans are relatively common.
     This provides an interface so that these packages can be used with SciMLVerbosity.
     If the verbosity is `Silent`, then `false` is returned. Otherwise, `true` is returned.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,27 +7,21 @@ const LOGGING_BACKEND = @load_preference("logging_backend", "logging")
 Base for types which specify which log messages are emitted at what level.
     
 """
-abstract type AbstractVerbositySpecifier end
+abstract type AbstractVerbositySpecifier{Enabled} end
 
 # Utilities
 
-function logging_message_level(option)
-    if option isa DebugLevel
-        return Logging.Debug
-    elseif option isa InfoLevel
-        return Logging.Info
-    elseif option isa WarnLevel
-        return Logging.Warn
-    elseif option isa ErrorLevel
-        return Logging.Error
-    elseif option isa CustomLevel
-        return Logging.LogLevel(option.level)
-    end
+function logging_message_level(m::MessageLevel)
+    m == Silent     && return nothing
+    m == DebugLevel && return Logging.Debug
+    m == InfoLevel  && return Logging.Info
+    m == WarnLevel  && return Logging.Warn
+    m == ErrorLevel && return Logging.Error
+    return Logging.LogLevel(m.level)
 end
 
-function logging_message_level(option::Silent)
-    return nothing
-end
+logging_message_level(::AbstractVerbosityPreset) = nothing
+logging_message_level(::AbstractVerbositySpecifier) = nothing
 
 function emit_message(
         f::Function, level, option, file, line,
@@ -100,12 +94,16 @@ function _emit_log(level, message, _module, file, line; kwargs...)
     return nothing
 end
 
-function get_message_level(verb::AbstractVerbositySpecifier, option)
+function get_message_level(::AbstractVerbositySpecifier{false}, ::Any)
+    return nothing
+end
+
+function get_message_level(verb::AbstractVerbositySpecifier{true}, option)
     return logging_message_level(getproperty(verb, option))
 end
 
 function get_message_level(verb::Bool, _)
-    return verb ? logging_message_level(WarnLevel()) : logging_message_level(Silent())
+    return verb ? logging_message_level(WarnLevel) : nothing
 end
 
 
@@ -208,15 +206,17 @@ macro SciMLMessage(f_or_message, verb, option, exs...)
     end
 
     expr = quote
-        emit_message(
-            $(esc(f_or_message)),
-            get_message_level($(esc(verb)), $(esc(option))),
-            $(esc(option)),
-            $file,
-            $line,
-            $_module;
-            $(kwargs...)
-        )
+        let _sciml_level = get_message_level($(esc(verb)), $(esc(option)))
+            _sciml_level !== nothing && emit_message(
+                $(esc(f_or_message)),
+                _sciml_level,
+                $(esc(option)),
+                $file,
+                $line,
+                $_module;
+                $(kwargs...)
+            )
+        end
     end
     return expr
 end
@@ -251,22 +251,13 @@ end
     verbosity_to_int(CustomLevel(-5)) # Returns -5
     ```
 """
-function verbosity_to_int(verb::AbstractMessageLevel)
-    if verb isa Silent
-        return 0
-    elseif verb isa DebugLevel
-        return 1
-    elseif verb isa InfoLevel
-        return 2
-    elseif verb isa WarnLevel
-        return 3
-    elseif verb isa ErrorLevel
-        return 4
-    elseif verb isa CustomLevel
-        return verb.level
-    else
-        return 0
-    end
+function verbosity_to_int(verb::MessageLevel)
+    verb == Silent     && return 0
+    verb == DebugLevel && return 1
+    verb == InfoLevel  && return 2
+    verb == WarnLevel  && return 3
+    verb == ErrorLevel && return 4
+    return verb.level
 end
 
 """
@@ -291,12 +282,8 @@ end
     ```
 
 """
-function verbosity_to_bool(verb::AbstractMessageLevel)
-    if verb isa Silent
-        return false
-    else
-        return true
-    end
+function verbosity_to_bool(verb::MessageLevel)
+    return verb != Silent
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@ abstract type AbstractVerbositySpecifier{Enabled} end
 
 # Utilities
 
-function logging_message_level(m::MessageLevel)
+Base.@assume_effects :foldable @inline function logging_message_level(m::MessageLevel)
     m == Silent     && return nothing
     m == DebugLevel && return Logging.Debug
     m == InfoLevel  && return Logging.Info
@@ -94,15 +94,15 @@ function _emit_log(level, message, _module, file, line; kwargs...)
     return nothing
 end
 
-function get_message_level(::AbstractVerbositySpecifier{false}, ::Any)
+Base.@assume_effects :foldable @inline function get_message_level(::AbstractVerbositySpecifier{false}, ::Any)
     return nothing
 end
 
-function get_message_level(verb::AbstractVerbositySpecifier{true}, option)
+Base.@assume_effects :foldable @inline function get_message_level(verb::AbstractVerbositySpecifier{true}, option)
     return logging_message_level(getproperty(verb, option))
 end
 
-function get_message_level(verb::Bool, _)
+Base.@assume_effects :foldable @inline function get_message_level(verb::Bool, _)
     return verb ? logging_message_level(WarnLevel) : nothing
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -247,8 +247,8 @@ end
 
     # Custom levels
 
-    verbosity_to_int(CustomLevel(10)) # Returns 10
-    verbosity_to_int(CustomLevel(-5)) # Returns -5
+    verbosity_to_int(MessageLevel(10)) # Returns 10
+    verbosity_to_int(MessageLevel(-5)) # Returns -5
     ```
 """
 function verbosity_to_int(verb::MessageLevel)
@@ -278,7 +278,7 @@ end
     verbosity_to_bool(InfoLevel)     # Returns true
     verbosity_to_bool(WarnLevel)     # Returns true
     verbosity_to_bool(ErrorLevel)    # Returns true
-    verbosity_to_bool(CustomLevel(5))  # Returns true
+    verbosity_to_bool(MessageLevel(5))  # Returns true
     ```
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@ abstract type AbstractVerbositySpecifier{Enabled} end
 
 # Utilities
 
-Base.@assume_effects :foldable @inline function logging_message_level(m::MessageLevel)
+@inline function logging_message_level(m::MessageLevel)
     m == Silent     && return nothing
     m == DebugLevel && return Logging.Debug
     m == InfoLevel  && return Logging.Info
@@ -94,15 +94,15 @@ function _emit_log(level, message, _module, file, line; kwargs...)
     return nothing
 end
 
-Base.@assume_effects :foldable @inline function get_message_level(::AbstractVerbositySpecifier{false}, ::Any)
+@inline function get_message_level(::AbstractVerbositySpecifier{false}, ::Any)
     return nothing
 end
 
-Base.@assume_effects :foldable @inline function get_message_level(verb::AbstractVerbositySpecifier{true}, option)
+@inline function get_message_level(verb::AbstractVerbositySpecifier{true}, option)
     return logging_message_level(getproperty(verb, option))
 end
 
-Base.@assume_effects :foldable @inline function get_message_level(verb::Bool, _)
+@inline function get_message_level(verb::Bool, _)
     return verb ? logging_message_level(WarnLevel) : nothing
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -127,12 +127,12 @@ The macro works with any `AbstractVerbositySpecifier` implementation:
 
 ```julia
 # Package defines verbosity specifier
-@concrete struct SolverVerbosity <: AbstractVerbositySpecifier
-    initialization
-    progress
-    convergence
-    diagnostics
-    performance
+struct SolverVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    initialization::MessageLevel
+    progress::MessageLevel
+    convergence::MessageLevel
+    diagnostics::MessageLevel
+    performance::MessageLevel
 end
 
 # Usage in package code

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,8 +11,10 @@ abstract type AbstractVerbositySpecifier{Enabled} end
 
 # Utilities
 
-@inline function logging_message_level(m::MessageLevel)
-    m == Silent     && return nothing
+# Convert a MessageLevel to a Julia Logging.LogLevel. Used only by the
+# Logging backend at the point where we actually hand off to Julia's logging
+# system — other backends (core, tracy) consume the MessageLevel directly.
+@inline function to_loglevel(m::MessageLevel)
     m == DebugLevel && return Logging.Debug
     m == InfoLevel  && return Logging.Info
     m == WarnLevel  && return Logging.Warn
@@ -20,11 +22,8 @@ abstract type AbstractVerbositySpecifier{Enabled} end
     return Logging.LogLevel(m.level)
 end
 
-logging_message_level(::AbstractVerbosityPreset) = nothing
-logging_message_level(::AbstractVerbositySpecifier) = nothing
-
 function emit_message(
-        f::Function, level, option, file, line,
+        f::Function, level::MessageLevel, option, file, line,
         _module; kwargs...
     )
     message = f()
@@ -34,17 +33,17 @@ function emit_message(
     elseif LOGGING_BACKEND == "tracy"
         emit_tracy_message(msg, level, file, line, _module)
     else
-        _emit_log(level, msg, _module, file, line; kwargs...)
+        _emit_log(to_loglevel(level), msg, _module, file, line; kwargs...)
     end
 
-    return if level == Logging.Error
+    return if level == ErrorLevel
         throw(ErrorException(msg))
     end
 end
 
 function emit_message(
         message::AbstractString,
-        level, option, file, line, _module; kwargs...
+        level::MessageLevel, option, file, line, _module; kwargs...
     )
 
     msg = "Verbosity toggle: $option \n $message"
@@ -53,10 +52,10 @@ function emit_message(
     elseif LOGGING_BACKEND == "tracy"
         emit_tracy_message(msg, level, file, line, _module)
     else
-        _emit_log(level, msg, _module, file, line; kwargs...)
+        _emit_log(to_loglevel(level), msg, _module, file, line; kwargs...)
     end
 
-    return if level == Logging.Error
+    return if level == ErrorLevel
         throw(ErrorException(msg))
     end
 end
@@ -99,11 +98,14 @@ end
 end
 
 @inline function get_message_level(verb::AbstractVerbositySpecifier{true}, option)
-    return logging_message_level(getproperty(verb, option))
+    m = getproperty(verb, option)
+    # Toggle access returns a MessageLevel (Silent → no emission). Sub-specifier
+    # access returns a spec/preset, which doesn't make sense here — treat as no-op.
+    return m isa MessageLevel && m != Silent ? m : nothing
 end
 
 @inline function get_message_level(verb::Bool, _)
-    return verb ? logging_message_level(WarnLevel) : nothing
+    return verb ? WarnLevel : nothing
 end
 
 

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -1,89 +1,64 @@
 """
-    AbstractMessageLevel
+    MessageLevel
 
-Abstract base type for all verbosity log levels in SciMLLogging.
+A concrete type representing a log message level, backed by an integer.
 
-Log levels determine the severity/importance of messages. Concrete subtypes include:
-- `Silent`: No output
-- `DebugLevel`: Debug messages
-- `InfoLevel`: Informational messages
-- `WarnLevel`: Warning messages
-- `ErrorLevel`: Error messages
-- `CustomLevel(n)`: Custom log level with integer value `n`
+Higher integer values correspond to higher severity. The standard levels are
+available as constants: `Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`, `ErrorLevel`.
+Custom levels can be created with `MessageLevel(n)` for any integer `n`.
 """
-abstract type AbstractMessageLevel end
-
-"""
-    Silent <: AbstractMessageLevel
-
-Log level that produces no output. When a message category is set to `Silent()`,
-no messages will be emitted for that category.
-"""
-struct Silent <: AbstractMessageLevel end
-
-"""
-    DebugLevel <: AbstractMessageLevel
-
-Debug log level. Messages at this level provide detailed debugging information,
-typically more verbose than informational messages. Useful for development and
-troubleshooting. 
-
-Corresponds to `Logging.Debug == Logging.LogLevel(-1000)` when using the Logging backend.
-
-By default, these messages are not logged at all, and the 
-`JULIA_DEBUG` environment variable needs to be set.
-For details see the [Julia Logging documentation](https://docs.julialang.org/en/v1/stdlib/Logging/#Environment-variables).
-"""
-struct DebugLevel <: AbstractMessageLevel end
-
-"""
-    InfoLevel <: AbstractMessageLevel
-
-Informational log level. Messages at this level provide general information about the progress or state of the computation. 
-
-Corresponds to `Logging.Info == Logging.LogLevel(0)` when using the Logging backend.
-"""
-struct InfoLevel <: AbstractMessageLevel end
-
-"""
-    WarnLevel <: AbstractMessageLevel
-
-Warning log level. Messages at this level indicate potential issues or
-situations that may require attention but don't prevent execution.
-
-Corresponds to `Logging.Warn == Logging.LogLevel(1000)` when using the Logging backend.
-"""
-struct WarnLevel <: AbstractMessageLevel end
-
-"""
-    ErrorLevel <: AbstractMessageLevel
-
-Error log level. Messages at this level indicate serious problems or
-failures in the computation.
-
-Corresponds to `Logging.Warn == Logging.LogLevel(2000)` when using the Logging backend.
-"""
-struct ErrorLevel <: AbstractMessageLevel end
-
-"""
-    CustomLevel(n::Int) <: AbstractMessageLevel
-
-Custom log level with integer value `n`. This allows creating custom
-severity levels beyond the standard Info/Warn/Error hierarchy.
-
-Corresponds to `Logging.LogLevel(n)`, where `n` is any integer, when using the Logging backend.
-
-Higher integer values typically indicate higher priority/severity.
-
-# Example
-```julia
-debug_level = CustomLevel(-1000)  # Very low priority debug messages
-critical_level = CustomLevel(1000)  # Very high priority critical messages
-```
-"""
-struct CustomLevel <: AbstractMessageLevel
+struct MessageLevel
     level::Int
 end
+
+"""
+    Silent
+
+Log level that produces no output.
+"""
+const Silent = MessageLevel(0)
+
+"""
+    DebugLevel
+
+Debug log level. Corresponds to `Logging.Debug` when using the Logging backend.
+"""
+const DebugLevel = MessageLevel(1)
+
+"""
+    InfoLevel
+
+Informational log level. Corresponds to `Logging.Info` when using the Logging backend.
+"""
+const InfoLevel = MessageLevel(2)
+
+"""
+    WarnLevel
+
+Warning log level. Corresponds to `Logging.Warn` when using the Logging backend.
+"""
+const WarnLevel = MessageLevel(3)
+
+"""
+    ErrorLevel
+
+Error log level. Corresponds to `Logging.Error` when using the Logging backend.
+"""
+const ErrorLevel = MessageLevel(4)
+
+"""
+    CustomLevel(n::Int)
+
+Construct a custom log level with integer value `n`. Corresponds to `Logging.LogLevel(n)`
+when using the Logging backend.
+"""
+const CustomLevel = MessageLevel
+
+# Allow calling level constants with no args for backward compatibility: Silent(), InfoLevel(), etc.
+(m::MessageLevel)() = m
+
+# Backward-compatible type alias
+const AbstractMessageLevel = MessageLevel
 
 """
     AbstractVerbosityPreset
@@ -103,7 +78,7 @@ abstract type AbstractVerbosityPreset end
 """
     None <: AbstractVerbosityPreset
 
-Preset that disables all verbosity. All message categories should be set to to `Silent()`.
+Preset that disables all verbosity. All message categories should be set to to `Silent`.
 """
 struct None <: AbstractVerbosityPreset end
 
@@ -112,12 +87,12 @@ struct None <: AbstractVerbosityPreset end
 
 Preset that shows only essential messages. Typically includes only warnings,
 errors, and critical status information while suppressing routine progress
-and debugging messages. 
+and debugging messages.
 
-This verbosity preset should set messages related to critical failures and 
-errors that stop computation to `ErrorLevel`. Messages related to fatal issues 
-(e.g., convergence problems, solver exiting, etc.) should be set to `WarnLevel()`. 
-All other messages should be set to `Silent()`.
+This verbosity preset should set messages related to critical failures and
+errors that stop computation to `ErrorLevel`. Messages related to fatal issues
+(e.g., convergence problems, solver exiting, etc.) should be set to `WarnLevel`.
+All other messages should be set to `Silent`.
 """
 struct Minimal <: AbstractVerbosityPreset end
 
@@ -128,8 +103,8 @@ Preset that provides balanced verbosity suitable for typical usage.
 Shows important progress and status information without overwhelming
 the user with details.
 
-This verbosity preset should include the settings from `Minimal`, while also setting 
-messages such as non-fatal deprecations and critical warnings that require handling 
+This verbosity preset should include the settings from `Minimal`, while also setting
+messages such as non-fatal deprecations and critical warnings that require handling
 to `InfoLevel`.
 """
 struct Standard <: AbstractVerbosityPreset end
@@ -141,10 +116,10 @@ Preset that provides comprehensive verbosity for debugging and detailed
 analysis. Shows most or all available message categories to help with
 troubleshooting and understanding program behavior.
 
-This verbosity preset should include the settings from `Standard`, plus progress updates 
-(e.g., iteration counters, intermediate state), performance metrics 
+This verbosity preset should include the settings from `Standard`, plus progress updates
+(e.g., iteration counters, intermediate state), performance metrics
 (e.g., timing information, memory usage), detailed diagnostics, and internal state information.
-The only messages that should be `Silent()` at this preset are very small details that would 
+The only messages that should be `Silent` at this preset are very small details that would
 clutter output even during debugging, and information that would be expensive to calculate.
 """
 struct Detailed <: AbstractVerbosityPreset end
@@ -156,6 +131,6 @@ Preset that enables maximum verbosity. All message categories are typically
 set to show informational messages or their appropriate levels.
 
 This verbosity preset should include the settings from `Detailed`, plus even more details.
-At this preset, no messages should be `Silent()`. 
+At this preset, no messages should be `Silent`.
 """
 struct All <: AbstractVerbosityPreset end

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -46,14 +46,6 @@ Error log level. Corresponds to `Logging.Error` when using the Logging backend.
 """
 const ErrorLevel = MessageLevel(4)
 
-"""
-    CustomLevel(n::Int)
-
-Construct a custom log level with integer value `n`. Corresponds to `Logging.LogLevel(n)`
-when using the Logging backend.
-"""
-const CustomLevel = MessageLevel
-
 # Allow calling level constants with no args for backward compatibility: Silent(), InfoLevel(), etc.
 (m::MessageLevel)() = m
 

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -57,9 +57,6 @@ const CustomLevel = MessageLevel
 # Allow calling level constants with no args for backward compatibility: Silent(), InfoLevel(), etc.
 (m::MessageLevel)() = m
 
-# Backward-compatible type alias
-const AbstractMessageLevel = MessageLevel
-
 """
     AbstractVerbosityPreset
 

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -66,10 +66,10 @@ end
 ```
 """
 macro verbosity_specifier(name, block)
-    local toggles_expr    = nothing
+    local toggles_expr = nothing
     local specifiers_expr = nothing
-    local presets_expr    = nothing
-    local groups_expr     = nothing
+    local presets_expr = nothing
+    local groups_expr = nothing
 
     if block.head == :block
         for ex in block.args
@@ -91,7 +91,7 @@ macro verbosity_specifier(name, block)
 
     toggles_expr !== nothing || throw(ArgumentError("toggles must be defined in block"))
     presets_expr !== nothing || throw(ArgumentError("presets must be defined in block"))
-    groups_expr  !== nothing || throw(ArgumentError("groups must be defined in block"))
+    groups_expr !== nothing || throw(ArgumentError("groups must be defined in block"))
 
     toggles_expr.head == :tuple || throw(ArgumentError("toggles must be a tuple"))
     toggles = [t.value for t in toggles_expr.args]
@@ -109,7 +109,7 @@ macro verbosity_specifier(name, block)
     presets_dict = Dict()
     for preset_def in presets_expr.args
         preset_def.head == :(=) || throw(ArgumentError("Each preset must be name = (...)"))
-        preset_name   = preset_def.args[1]
+        preset_name = preset_def.args[1]
         preset_values = preset_def.args[2]
         preset_values.head == :tuple || throw(ArgumentError("Preset values must be a NamedTuple"))
         preset_config = Dict()
@@ -124,17 +124,17 @@ macro verbosity_specifier(name, block)
     groups_dict = Dict()
     for group_def in groups_expr.args
         group_def.head == :(=) || throw(ArgumentError("Each group must be name = (...)"))
-        group_name        = group_def.args[1]
+        group_name = group_def.args[1]
         group_fields_expr = group_def.args[2]
         group_fields_expr.head == :tuple || throw(ArgumentError("Group fields must be a tuple"))
         groups_dict[group_name] = [t isa QuoteNode ? t.value : t for t in group_fields_expr.args]
     end
 
     preset_names = collect(keys(presets_dict))
-    group_names  = collect(keys(groups_dict))
+    group_names = collect(keys(groups_dict))
 
-    standard_presets   = (:None, :Minimal, :Standard, :Detailed, :All)
-    custom_presets     = filter(p -> !(p in standard_presets), preset_names)
+    standard_presets = (:None, :Minimal, :Standard, :Detailed, :All)
+    custom_presets = filter(p -> !(p in standard_presets), preset_names)
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
     # If specifiers section is declared, toggles get concrete ::MessageLevel fields
@@ -145,18 +145,18 @@ macro verbosity_specifier(name, block)
     # tail of LinearCache-style parameter chains collapsing into existentials.
     #
     # If no specifiers section, all fields use the wider Union for backward compatibility.
-    has_specifiers   = specifiers_expr !== nothing
+    has_specifiers = specifiers_expr !== nothing
     spec_type_params = has_specifiers ?
         [Symbol("__SPEC_T_", i) for i in 1:length(specifiers)] :
         Symbol[]
     toggle_field_type = has_specifiers ?
         :(SciMLLogging.MessageLevel) :
         :(Union{SciMLLogging.MessageLevel, SciMLLogging.AbstractVerbosityPreset, SciMLLogging.AbstractVerbositySpecifier})
-    toggle_fields    = [:($(t)::$toggle_field_type) for t in toggles]
+    toggle_fields = [:($(t)::$toggle_field_type) for t in toggles]
     specifier_fields = has_specifiers ?
         [:($(s)::$(spec_type_params[i])) for (i, s) in enumerate(specifiers)] :
         Expr[]
-    struct_fields    = [toggle_fields; specifier_fields]
+    struct_fields = [toggle_fields; specifier_fields]
 
     struct_type_params = [:Enabled; spec_type_params]
     struct_def = :(
@@ -174,10 +174,12 @@ macro verbosity_specifier(name, block)
     # emitting our own would shadow it and infinite-recurse.
     partial_app_ctor = if has_specifiers && !isempty(specifiers)
         all_arg_names = [Symbol("__arg_", f) for f in all_fields]
-        typeof_specs  = [:(typeof($(Symbol("__arg_", s)))) for s in specifiers]
-        :(function $name{Enabled}($(all_arg_names...)) where {Enabled}
-            return $name{Enabled, $(typeof_specs...)}($(all_arg_names...))
-        end)
+        typeof_specs = [:(typeof($(Symbol("__arg_", s)))) for s in specifiers]
+        :(
+            function $name{Enabled}($(all_arg_names...)) where {Enabled}
+                return $name{Enabled, $(typeof_specs...)}($(all_arg_names...))
+            end
+        )
     else
         nothing
     end
@@ -186,13 +188,15 @@ macro verbosity_specifier(name, block)
     preset_constructors = []
     for preset_name in preset_names
         preset_config = presets_dict[preset_name]
-        field_values  = [preset_config[f] for f in all_fields]
-        enabled       = preset_name === :None ? false : true
-        push!(preset_constructors, :(
-            function $name(::$preset_name)
-                return $name{$enabled}($(field_values...))
-            end
-        ))
+        field_values = [preset_config[f] for f in all_fields]
+        enabled = preset_name === :None ? false : true
+        push!(
+            preset_constructors, :(
+                function $name(::$preset_name)
+                    return $name{$enabled}($(field_values...))
+                end
+            )
+        )
     end
 
     # Map each field to its group
@@ -207,7 +211,7 @@ macro verbosity_specifier(name, block)
         end
     end
 
-    standard_config  = presets_dict[:Standard]
+    standard_config = presets_dict[:Standard]
     fast_path_values = [standard_config[f] for f in all_fields]
 
     # Group validation
@@ -217,17 +221,19 @@ macro verbosity_specifier(name, block)
             :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
             "\$($(QuoteNode(group_name))) must be a SciMLLogging.AbstractMessageLevel, got \$(typeof($(group_name)))"
         )
-        push!(group_validations, quote
-            if $(group_name) !== nothing && !($(group_name) isa AbstractMessageLevel)
-                throw(ArgumentError($lazy_str))
+        push!(
+            group_validations, quote
+                if $(group_name) !== nothing && !($(group_name) isa AbstractMessageLevel)
+                    throw(ArgumentError($lazy_str))
+                end
             end
-        end)
+        )
     end
 
     # Field assignments with precedence: individual > group > preset
     field_assignments = []
     for f in all_fields
-        group     = field_to_group[f]
+        group = field_to_group[f]
         field_key = QuoteNode(f)
         if group === nothing
             push!(field_assignments, :($f = haskey(kwargs, $field_key) ? kwargs[$field_key] : preset_config[$field_key]))
@@ -244,7 +250,7 @@ macro verbosity_specifier(name, block)
     end
     preset_map_const = :(const $(Symbol("_preset_map_", name)) = NamedTuple{$(Tuple(preset_names))}(($(preset_configs...),)))
 
-    kwarg_params      = [Expr(:kw, :preset, :nothing); [Expr(:kw, g, :nothing) for g in group_names]]
+    kwarg_params = [Expr(:kw, :preset, :nothing); [Expr(:kw, g, :nothing) for g in group_names]]
     runtime_condition = foldr((a, b) -> :($a && $b), [:($(g) === nothing) for g in group_names]; init = :(preset === nothing && isempty(kwargs)))
 
     preset_error_str = Expr(

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -18,7 +18,7 @@ Must include at least `Standard`. Can define custom presets beyond the standard 
 
 # Generated Code
 
-**Struct:** Creates `name{T1, T2, ...} <: AbstractVerbositySpecifier` with fields for each toggle.
+**Struct:** Creates `name{Enabled} <: AbstractVerbositySpecifier{Enabled}` with fields for each toggle.
 
 **Constructors:**
 - `name()`: Default constructor using Standard preset
@@ -120,26 +120,26 @@ macro verbosity_specifier(name, block)
     # Generate custom preset types
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
-    # Generate parametric struct
-    type_params = [Symbol("T$i") for i in eachindex(toggles)]
-    struct_fields = [:($(toggles[i])::$(type_params[i])) for i in eachindex(toggles)]
+    # Generate struct with single {Enabled} type param
+    struct_fields = [:($(toggles[i])::Union{SciMLLogging.MessageLevel, SciMLLogging.AbstractVerbosityPreset, SciMLLogging.AbstractVerbositySpecifier}) for i in eachindex(toggles)]
 
     struct_def = :(
-        struct $name{$(type_params...)} <: AbstractVerbositySpecifier
+        struct $name{Enabled} <: SciMLLogging.AbstractVerbositySpecifier{Enabled}
             $(struct_fields...)
         end
     )
 
-    # Generate preset constructors
+    # Generate preset constructors — None() produces {false}, everything else {true}
     preset_constructors = []
     for preset_name in preset_names
         preset_config = presets_dict[preset_name]
         field_values = [preset_config[t] for t in toggles]
+        enabled = preset_name === :None ? false : true
 
         push!(
             preset_constructors, :(
                 function $name(::$preset_name)
-                    return $name($(field_values...))
+                    return $name{$enabled}($(field_values...))
                 end
             )
         )
@@ -229,7 +229,7 @@ macro verbosity_specifier(name, block)
 
             # Fast path: all defaults
             if $runtime_condition
-                return $name($(fast_path_values...))
+                return $name{true}($(fast_path_values...))
             end
 
             # Validate groups
@@ -257,7 +257,7 @@ macro verbosity_specifier(name, block)
             # Apply precedence
             $(toggle_assignments...)
 
-            return $name($([t for t in toggles]...))
+            return $name{true}($([t for t in toggles]...))
         end
     end
 

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -138,11 +138,11 @@ macro verbosity_specifier(name, block)
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
     # If specifiers section is declared, toggles get concrete ::MessageLevel fields
-    # (enabling @assume_effects :foldable to fire) and each specifier gets its own
-    # type parameter, so the field type is concrete for whatever instance the user
-    # plugs in (a sub-specifier from another package, or a preset). This is what
-    # lets inference flow through `outer.inner` into downstream APIs without the
-    # tail of LinearCache-style parameter chains collapsing into existentials.
+    # and each specifier gets its own type parameter, so the field type is concrete
+    # for whatever instance the user plugs in (a sub-specifier from another package,
+    # or a preset). This is what lets inference flow through `outer.inner` into
+    # downstream APIs without the tail of LinearCache-style parameter chains
+    # collapsing into existentials.
     #
     # If no specifiers section, all fields use the wider Union for backward compatibility.
     has_specifiers = specifiers_expr !== nothing

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -57,8 +57,8 @@ given, the struct is just `name{Enabled}`.
 
     presets = (
         Standard = (
-            convergence      = InfoLevel(),
-            step_rejected    = WarnLevel(),
+            convergence      = InfoLevel,
+            step_rejected    = WarnLevel,
             linear_verbosity = LinearVerbosity(None()),
         ),
     )

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -1,6 +1,7 @@
 """
     @verbosity_specifier name begin
         toggles = (...)
+        specifiers = (...)   # optional
         presets = (...)
         groups = (...)
     end
@@ -9,47 +10,59 @@ Generates a parametric struct and constructors for a verbosity specifier.
 
 # Input Format
 
-**toggles:** Tuple of symbols defining the verbosity toggle names (e.g., `(:toggle1, :toggle2)`).
+**toggles:** Tuple of symbols for leaf verbosity toggles. Fields are typed as `MessageLevel`,
+enabling compile-time branch elimination when the specifier is a constant.
 
-**presets:** Named tuple mapping preset names to toggle configurations. Each preset maps toggle names to message levels or preset types.
-Must include at least `Standard`. Can define custom presets beyond the standard five (None, Minimal, Standard, Detailed, All).
+**specifiers:** (optional) Tuple of symbols for sub-specifier fields that hold another
+`AbstractVerbositySpecifier` or `AbstractVerbosityPreset`. Fields are typed as
+`Union{AbstractVerbositySpecifier, AbstractVerbosityPreset}`.
 
-**groups:** Named tuple mapping group names to tuples of toggle symbols. Groups allow setting multiple toggles at once.
+**presets:** Named tuple mapping preset names to field configurations. Each preset maps
+field names to message levels, presets, or specifier instances.
+Must include at least `Standard`. Can define custom presets beyond the standard five
+(None, Minimal, Standard, Detailed, All).
+
+**groups:** Named tuple mapping group names to tuples of field symbols. Groups allow
+setting multiple fields at once.
 
 # Generated Code
 
-**Struct:** Creates `name{Enabled} <: AbstractVerbositySpecifier{Enabled}` with fields for each toggle.
+**Struct:** Creates `name{Enabled} <: AbstractVerbositySpecifier{Enabled}` with concrete
+`MessageLevel` fields for toggles and Union fields for specifiers.
 
 **Constructors:**
 - `name()`: Default constructor using Standard preset
-- `name(preset::AbstractVerbosityPreset)`: Constructor from preset (e.g., `name(Minimal())`) for each preset in presets
+- `name(preset::AbstractVerbosityPreset)`: Constructor from preset (e.g., `name(Minimal())`)
 - `name(; preset=nothing, groups..., kwargs...)`: Keyword constructor with precedence: individual > group > preset
 
-**Custom Preset Types:** Generates struct definitions for non-standard presets (beyond None, Minimal, Standard, Detailed, All).
+**Custom Preset Types:** Generates struct definitions for non-standard presets.
 
 # Example
 ```julia
-@verbosity_specifier MyVerbosity begin
-    toggles = (:toggle1, :toggle2)
+@verbosity_specifier SolverVerbosity begin
+    toggles = (:convergence, :step_rejected)
+
+    specifiers = (:linear_verbosity,)
 
     presets = (
         Standard = (
-            toggle1 = InfoLevel(),
-            toggle2 = WarnLevel()
+            convergence      = InfoLevel(),
+            step_rejected    = WarnLevel(),
+            linear_verbosity = LinearVerbosity(None()),
         ),
     )
 
     groups = (
-        group1 = (:toggle1,),
+        solver = (:convergence, :step_rejected),
     )
 end
 ```
 """
 macro verbosity_specifier(name, block)
-    # Extract the three assignments from the block
-    local toggles_expr = nothing
-    local presets_expr = nothing
-    local groups_expr = nothing
+    local toggles_expr    = nothing
+    local specifiers_expr = nothing
+    local presets_expr    = nothing
+    local groups_expr     = nothing
 
     if block.head == :block
         for ex in block.args
@@ -58,6 +71,8 @@ macro verbosity_specifier(name, block)
                 rhs = ex.args[2]
                 if lhs == :toggles
                     toggles_expr = rhs
+                elseif lhs == :specifiers
+                    specifiers_expr = rhs
                 elseif lhs == :presets
                     presets_expr = rhs
                 elseif lhs == :groups
@@ -69,59 +84,57 @@ macro verbosity_specifier(name, block)
 
     toggles_expr !== nothing || throw(ArgumentError("toggles must be defined in block"))
     presets_expr !== nothing || throw(ArgumentError("presets must be defined in block"))
-    groups_expr !== nothing || throw(ArgumentError("groups must be defined in block"))
+    groups_expr  !== nothing || throw(ArgumentError("groups must be defined in block"))
 
-    # Parse toggles - should be a tuple of symbols
     toggles_expr.head == :tuple || throw(ArgumentError("toggles must be a tuple"))
-    # Extract the actual symbols from QuoteNode objects
     toggles = [t.value for t in toggles_expr.args]
 
-    # Parse presets - should be a NamedTuple
+    specifiers = if specifiers_expr !== nothing
+        specifiers_expr.head == :tuple || throw(ArgumentError("specifiers must be a tuple"))
+        [t.value for t in specifiers_expr.args]
+    else
+        Symbol[]
+    end
+
+    all_fields = [toggles; specifiers]
+
     presets_expr.head == :tuple || throw(ArgumentError("presets must be a NamedTuple"))
     presets_dict = Dict()
     for preset_def in presets_expr.args
         preset_def.head == :(=) || throw(ArgumentError("Each preset must be name = (...)"))
-        preset_name = preset_def.args[1]
+        preset_name   = preset_def.args[1]
         preset_values = preset_def.args[2]
         preset_values.head == :tuple || throw(ArgumentError("Preset values must be a NamedTuple"))
-
-        # Parse the preset configuration
         preset_config = Dict()
-        for toggle_def in preset_values.args
-            toggle_def.head == :(=) || throw(ArgumentError("Each toggle must be toggle_name = value"))
-            toggle_name = toggle_def.args[1]
-            toggle_value_expr = toggle_def.args[2]
-            preset_config[toggle_name] = toggle_value_expr
+        for field_def in preset_values.args
+            field_def.head == :(=) || throw(ArgumentError("Each field must be field_name = value"))
+            preset_config[field_def.args[1]] = field_def.args[2]
         end
         presets_dict[preset_name] = preset_config
     end
 
-    # Parse groups
     groups_expr.head == :tuple || throw(ArgumentError("groups must be a NamedTuple"))
     groups_dict = Dict()
     for group_def in groups_expr.args
         group_def.head == :(=) || throw(ArgumentError("Each group must be name = (...)"))
-        group_name = group_def.args[1]
-        group_toggles_expr = group_def.args[2]
-        group_toggles_expr.head == :tuple || throw(ArgumentError("Group toggles must be a tuple"))
-        # Extract the actual symbols from QuoteNode objects
-        group_toggles = [t isa QuoteNode ? t.value : t for t in group_toggles_expr.args]
-        groups_dict[group_name] = group_toggles
+        group_name        = group_def.args[1]
+        group_fields_expr = group_def.args[2]
+        group_fields_expr.head == :tuple || throw(ArgumentError("Group fields must be a tuple"))
+        groups_dict[group_name] = [t isa QuoteNode ? t.value : t for t in group_fields_expr.args]
     end
 
-    # Now generate the code
     preset_names = collect(keys(presets_dict))
-    group_names = collect(keys(groups_dict))
+    group_names  = collect(keys(groups_dict))
 
-    # Standard presets that already exist
-    standard_presets = (:None, :Minimal, :Standard, :Detailed, :All)
-    custom_presets = filter(p -> !(p in standard_presets), preset_names)
-
-    # Generate custom preset types
+    standard_presets   = (:None, :Minimal, :Standard, :Detailed, :All)
+    custom_presets     = filter(p -> !(p in standard_presets), preset_names)
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
-    # Generate struct with single {Enabled} type param
-    struct_fields = [:($(toggles[i])::Union{SciMLLogging.MessageLevel, SciMLLogging.AbstractVerbosityPreset, SciMLLogging.AbstractVerbositySpecifier}) for i in eachindex(toggles)]
+    # Toggles: concrete MessageLevel — enables @assume_effects :foldable to fire
+    # Specifiers: Union for sub-specifiers and presets
+    toggle_fields    = [:($(t)::SciMLLogging.MessageLevel) for t in toggles]
+    specifier_fields = [:($(s)::Union{SciMLLogging.AbstractVerbositySpecifier, SciMLLogging.AbstractVerbosityPreset}) for s in specifiers]
+    struct_fields    = [toggle_fields; specifier_fields]
 
     struct_def = :(
         struct $name{Enabled} <: SciMLLogging.AbstractVerbositySpecifier{Enabled}
@@ -129,139 +142,122 @@ macro verbosity_specifier(name, block)
         end
     )
 
-    # Generate preset constructors — None() produces {false}, everything else {true}
+    # Preset constructors — None() produces {false}, everything else {true}
     preset_constructors = []
     for preset_name in preset_names
         preset_config = presets_dict[preset_name]
-        field_values = [preset_config[t] for t in toggles]
-        enabled = preset_name === :None ? false : true
-
-        push!(
-            preset_constructors, :(
-                function $name(::$preset_name)
-                    return $name{$enabled}($(field_values...))
-                end
-            )
-        )
+        field_values  = [preset_config[f] for f in all_fields]
+        enabled       = preset_name === :None ? false : true
+        push!(preset_constructors, :(
+            function $name(::$preset_name)
+                return $name{$enabled}($(field_values...))
+            end
+        ))
     end
 
-    # Build toggle to group mapping
-    toggle_to_group = Dict{Symbol, Union{Symbol, Nothing}}()
-    for toggle in toggles
-        toggle_to_group[toggle] = nothing
-        for (group_name, group_toggles) in groups_dict
-            if toggle in group_toggles
-                toggle_to_group[toggle] = group_name
+    # Map each field to its group
+    field_to_group = Dict{Symbol, Union{Symbol, Nothing}}()
+    for f in all_fields
+        field_to_group[f] = nothing
+        for (group_name, group_fields) in groups_dict
+            if f in group_fields
+                field_to_group[f] = group_name
                 break
             end
         end
     end
 
-    # Get Standard preset config for fast path
-    standard_config = presets_dict[:Standard]
-    fast_path_values = [standard_config[t] for t in toggles]
+    standard_config  = presets_dict[:Standard]
+    fast_path_values = [standard_config[f] for f in all_fields]
 
-    # Build validation for groups
+    # Group validation
     group_validations = []
     for group_name in group_names
         lazy_str = Expr(
             :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
             "\$($(QuoteNode(group_name))) must be a SciMLLogging.AbstractMessageLevel, got \$(typeof($(group_name)))"
         )
-        push!(
-            group_validations, quote
-                if $(group_name) !== nothing && !($(group_name) isa AbstractMessageLevel)
-                    throw(ArgumentError($lazy_str))
-                end
+        push!(group_validations, quote
+            if $(group_name) !== nothing && !($(group_name) isa AbstractMessageLevel)
+                throw(ArgumentError($lazy_str))
             end
-        )
+        end)
     end
 
-    # Build precedence logic for each toggle
-    toggle_assignments = []
-    for toggle in toggles
-        group = toggle_to_group[toggle]
-        toggle_key = QuoteNode(toggle)
-
+    # Field assignments with precedence: individual > group > preset
+    field_assignments = []
+    for f in all_fields
+        group     = field_to_group[f]
+        field_key = QuoteNode(f)
         if group === nothing
-            # Not in any group: individual > preset
-            # Build preset_config inline as a tuple access
-            push!(toggle_assignments, :($toggle = haskey(kwargs, $toggle_key) ? kwargs[$toggle_key] : preset_config[$toggle_key]))
+            push!(field_assignments, :($f = haskey(kwargs, $field_key) ? kwargs[$field_key] : preset_config[$field_key]))
         else
-            # In a group: individual > group > preset
-            push!(toggle_assignments, :($toggle = haskey(kwargs, $toggle_key) ? kwargs[$toggle_key] : ($group !== nothing ? $group : preset_config[$toggle_key])))
+            push!(field_assignments, :($f = haskey(kwargs, $field_key) ? kwargs[$field_key] : ($group !== nothing ? $group : preset_config[$field_key])))
         end
     end
 
-    # Build preset_map as a constant NamedTuple for runtime access
-    # For each preset, create a NamedTuple of its toggle configurations
+    # Preset map constant
     preset_configs = []
     for pname in preset_names
-        toggle_values = [presets_dict[pname][t] for t in toggles]
-        # Use tuple of symbols for NamedTuple type parameter
-        push!(preset_configs, :(NamedTuple{$(Tuple(toggles))}(($(toggle_values...),))))
+        field_values = [presets_dict[pname][f] for f in all_fields]
+        push!(preset_configs, :(NamedTuple{$(Tuple(all_fields))}(($(field_values...),))))
     end
-
-    # Use tuple of symbols for preset names
     preset_map_const = :(const $(Symbol("_preset_map_", name)) = NamedTuple{$(Tuple(preset_names))}(($(preset_configs...),)))
 
-    # Build main constructor
-    kwarg_params = [Expr(:kw, :preset, :nothing); [Expr(:kw, g, :nothing) for g in group_names]]
+    kwarg_params      = [Expr(:kw, :preset, :nothing); [Expr(:kw, g, :nothing) for g in group_names]]
     runtime_condition = foldr((a, b) -> :($a && $b), [:($(g) === nothing) for g in group_names]; init = :(preset === nothing && isempty(kwargs)))
 
-    # Build lazy string expressions
     preset_error_str = Expr(
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
         "preset must be a SciMLLogging.AbstractVerbosityPreset, got \$(typeof(preset))"
     )
     unknown_option_str = Expr(
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
-        "Unknown verbosity option: \$key. Valid options are: $(Tuple(toggles))"
+        "Unknown verbosity option: \$key. Valid options are: $(Tuple(all_fields))"
     )
-    invalid_type_str = Expr(
+    toggle_type_str = Expr(
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
-        "\$key must be a SciMLLogging.AbstractMessageLevel, AbstractVerbosityPreset, or AbstractVerbositySpecifier, got \$(typeof(value))"
+        "\$key is a toggle and must be a SciMLLogging.MessageLevel, got \$(typeof(value))"
+    )
+    specifier_type_str = Expr(
+        :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
+        "\$key is a specifier field and must be a SciMLLogging.AbstractVerbositySpecifier or AbstractVerbosityPreset, got \$(typeof(value))"
     )
 
     main_constructor = quote
         function $name(; $(kwarg_params...), kwargs...)
             kwargs = NamedTuple(kwargs)
 
-            # Fast path: all defaults
             if $runtime_condition
                 return $name{true}($(fast_path_values...))
             end
 
-            # Validate groups
             $(group_validations...)
 
-            # Validate preset
             if preset !== nothing && !(preset isa AbstractVerbosityPreset)
                 throw(ArgumentError($preset_error_str))
             end
 
-            # Validate kwargs
             for (key, value) in pairs(kwargs)
-                if !(key in $(Tuple(toggles)))
+                if key in $(Tuple(toggles))
+                    !(value isa MessageLevel) && throw(ArgumentError($toggle_type_str))
+                elseif key in $(Tuple(specifiers))
+                    !(value isa AbstractVerbositySpecifier || value isa AbstractVerbosityPreset) &&
+                        throw(ArgumentError($specifier_type_str))
+                else
                     throw(ArgumentError($unknown_option_str))
-                end
-                if !(value isa AbstractMessageLevel || value isa AbstractVerbosityPreset || value isa AbstractVerbositySpecifier)
-                    throw(ArgumentError($invalid_type_str))
                 end
             end
 
-            # Get preset config
             preset_to_use = preset === nothing ? Standard() : preset
             preset_config = $(Symbol("_preset_map_", name))[typeof(preset_to_use).name.name]
 
-            # Apply precedence
-            $(toggle_assignments...)
+            $(field_assignments...)
 
-            return $name{true}($([t for t in toggles]...))
+            return $name{true}($([f for f in all_fields]...))
         end
     end
 
-    # Assemble everything
     result = quote
         $(custom_preset_defs...)
         $preset_map_const

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -14,8 +14,13 @@ Generates a parametric struct and constructors for a verbosity specifier.
 enabling compile-time branch elimination when the specifier is a constant.
 
 **specifiers:** (optional) Tuple of symbols for sub-specifier fields that hold another
-`AbstractVerbositySpecifier` or `AbstractVerbosityPreset`. Fields are typed as
-`Union{AbstractVerbositySpecifier, AbstractVerbosityPreset}`.
+`AbstractVerbositySpecifier` or `AbstractVerbosityPreset`. Each specifier field becomes
+its own type parameter on the generated struct, so the field is concretely typed at the
+instance level. This preserves inference when the sub-specifier is forwarded to a
+downstream API (e.g. `solve(...; verbose = outer.linear_verbosity)`), and lets the
+outer-spec-defining package hold a sub-specifier type that it does not depend on at
+definition time (e.g. DiffEqBase holding a NonlinearVerbosity without depending on
+NonlinearSolve).
 
 **presets:** Named tuple mapping preset names to field configurations. Each preset maps
 field names to message levels, presets, or specifier instances.
@@ -27,8 +32,10 @@ setting multiple fields at once.
 
 # Generated Code
 
-**Struct:** Creates `name{Enabled} <: AbstractVerbositySpecifier{Enabled}` with concrete
-`MessageLevel` fields for toggles and Union fields for specifiers.
+**Struct:** Creates `name{Enabled, S1, ..., Sk} <: AbstractVerbositySpecifier{Enabled}`,
+where `S1..Sk` are the type parameters for each declared specifier (in order). Toggle
+fields are `::MessageLevel`. If no specifiers block is given, the struct is just
+`name{Enabled}` and toggle fields use a wider Union for backward compatibility.
 
 **Constructors:**
 - `name()`: Default constructor using Standard preset
@@ -131,20 +138,49 @@ macro verbosity_specifier(name, block)
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
     # If specifiers section is declared, toggles get concrete ::MessageLevel fields
-    # (enabling @assume_effects :foldable to fire) and specifiers get the Union.
-    # If no specifiers section, all fields use the Union for backward compatibility.
-    toggle_field_type = specifiers_expr !== nothing ?
+    # (enabling @assume_effects :foldable to fire) and each specifier gets its own
+    # type parameter, so the field type is concrete for whatever instance the user
+    # plugs in (a sub-specifier from another package, or a preset). This is what
+    # lets inference flow through `outer.inner` into downstream APIs without the
+    # tail of LinearCache-style parameter chains collapsing into existentials.
+    #
+    # If no specifiers section, all fields use the wider Union for backward compatibility.
+    has_specifiers   = specifiers_expr !== nothing
+    spec_type_params = has_specifiers ?
+        [Symbol("__SPEC_T_", i) for i in 1:length(specifiers)] :
+        Symbol[]
+    toggle_field_type = has_specifiers ?
         :(SciMLLogging.MessageLevel) :
         :(Union{SciMLLogging.MessageLevel, SciMLLogging.AbstractVerbosityPreset, SciMLLogging.AbstractVerbositySpecifier})
     toggle_fields    = [:($(t)::$toggle_field_type) for t in toggles]
-    specifier_fields = [:($(s)::Union{SciMLLogging.AbstractVerbositySpecifier, SciMLLogging.AbstractVerbosityPreset}) for s in specifiers]
+    specifier_fields = has_specifiers ?
+        [:($(s)::$(spec_type_params[i])) for (i, s) in enumerate(specifiers)] :
+        Expr[]
     struct_fields    = [toggle_fields; specifier_fields]
 
+    struct_type_params = [:Enabled; spec_type_params]
     struct_def = :(
-        struct $name{Enabled} <: SciMLLogging.AbstractVerbositySpecifier{Enabled}
+        struct $name{$(struct_type_params...)} <: SciMLLogging.AbstractVerbositySpecifier{Enabled}
             $(struct_fields...)
         end
     )
+
+    # When specifiers are present, the auto-generated constructor requires all type
+    # parameters. Add a partial-application outer constructor that takes only Enabled
+    # and lets Julia infer the specifier types from the arg types — so call sites
+    # everywhere can write `$name{true}(...)`.
+    # Skip if the specifiers tuple is declared empty: then the struct has no extra
+    # type params and the auto-generated `name{Enabled}(...)` already exists, so
+    # emitting our own would shadow it and infinite-recurse.
+    partial_app_ctor = if has_specifiers && !isempty(specifiers)
+        all_arg_names = [Symbol("__arg_", f) for f in all_fields]
+        typeof_specs  = [:(typeof($(Symbol("__arg_", s)))) for s in specifiers]
+        :(function $name{Enabled}($(all_arg_names...)) where {Enabled}
+            return $name{Enabled, $(typeof_specs...)}($(all_arg_names...))
+        end)
+    else
+        nothing
+    end
 
     # Preset constructors — None() produces {false}, everything else {true}
     preset_constructors = []
@@ -271,12 +307,23 @@ macro verbosity_specifier(name, block)
         end
     end
 
-    result = quote
-        $(custom_preset_defs...)
-        $preset_map_const
-        $struct_def
-        $(preset_constructors...)
-        $main_constructor
+    result = if partial_app_ctor === nothing
+        quote
+            $(custom_preset_defs...)
+            $preset_map_const
+            $struct_def
+            $(preset_constructors...)
+            $main_constructor
+        end
+    else
+        quote
+            $(custom_preset_defs...)
+            $preset_map_const
+            $struct_def
+            $partial_app_ctor
+            $(preset_constructors...)
+            $main_constructor
+        end
     end
 
     return esc(result)

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -130,9 +130,13 @@ macro verbosity_specifier(name, block)
     custom_presets     = filter(p -> !(p in standard_presets), preset_names)
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
-    # Toggles: concrete MessageLevel — enables @assume_effects :foldable to fire
-    # Specifiers: Union for sub-specifiers and presets
-    toggle_fields    = [:($(t)::SciMLLogging.MessageLevel) for t in toggles]
+    # If specifiers section is declared, toggles get concrete ::MessageLevel fields
+    # (enabling @assume_effects :foldable to fire) and specifiers get the Union.
+    # If no specifiers section, all fields use the Union for backward compatibility.
+    toggle_field_type = specifiers_expr !== nothing ?
+        :(SciMLLogging.MessageLevel) :
+        :(Union{SciMLLogging.MessageLevel, SciMLLogging.AbstractVerbosityPreset, SciMLLogging.AbstractVerbositySpecifier})
+    toggle_fields    = [:($(t)::$toggle_field_type) for t in toggles]
     specifier_fields = [:($(s)::Union{SciMLLogging.AbstractVerbositySpecifier, SciMLLogging.AbstractVerbosityPreset}) for s in specifiers]
     struct_fields    = [toggle_fields; specifier_fields]
 
@@ -215,6 +219,10 @@ macro verbosity_specifier(name, block)
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
         "Unknown verbosity option: \$key. Valid options are: $(Tuple(all_fields))"
     )
+    invalid_type_str = Expr(
+        :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
+        "\$key must be a SciMLLogging.MessageLevel, AbstractVerbosityPreset, or AbstractVerbositySpecifier, got \$(typeof(value))"
+    )
     toggle_type_str = Expr(
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
         "\$key is a toggle and must be a SciMLLogging.MessageLevel, got \$(typeof(value))"
@@ -240,7 +248,12 @@ macro verbosity_specifier(name, block)
 
             for (key, value) in pairs(kwargs)
                 if key in $(Tuple(toggles))
-                    !(value isa MessageLevel) && throw(ArgumentError($toggle_type_str))
+                    if $(specifiers_expr !== nothing)
+                        !(value isa MessageLevel) && throw(ArgumentError($toggle_type_str))
+                    else
+                        !(value isa AbstractMessageLevel || value isa AbstractVerbosityPreset || value isa AbstractVerbositySpecifier) &&
+                            throw(ArgumentError($invalid_type_str))
+                    end
                 elseif key in $(Tuple(specifiers))
                     !(value isa AbstractVerbositySpecifier || value isa AbstractVerbosityPreset) &&
                         throw(ArgumentError($specifier_type_str))

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -1,7 +1,7 @@
 """
     @verbosity_specifier name begin
         toggles = (...)
-        specifiers = (...)   # optional
+        sub_specifiers = (...)   # optional
         presets = (...)
         groups = (...)
     end
@@ -10,32 +10,36 @@ Generates a parametric struct and constructors for a verbosity specifier.
 
 # Input Format
 
-**toggles:** Tuple of symbols for leaf verbosity toggles. Fields are typed as `MessageLevel`,
-enabling compile-time branch elimination when the specifier is a constant.
+**toggles:** Tuple of symbols for leaf verbosity toggles. Fields are typed as
+`MessageLevel`. Each toggle controls whether (and at what level) a category of
+log messages is emitted.
 
-**specifiers:** (optional) Tuple of symbols for sub-specifier fields that hold another
-`AbstractVerbositySpecifier` or `AbstractVerbosityPreset`. Each specifier field becomes
-its own type parameter on the generated struct, so the field is concretely typed at the
-instance level. This preserves inference when the sub-specifier is forwarded to a
-downstream API (e.g. `solve(...; verbose = outer.linear_verbosity)`), and lets the
-outer-spec-defining package hold a sub-specifier type that it does not depend on at
-definition time (e.g. DiffEqBase holding a NonlinearVerbosity without depending on
-NonlinearSolve).
+**sub_specifiers:** (optional) Tuple of symbols for fields that hold another
+`AbstractVerbositySpecifier` or `AbstractVerbosityPreset` (a sub-spec for some
+nested concern, e.g. a `LinearVerbosity` inside a `DEVerbosity`). Each declared
+sub-specifier becomes its own type parameter on the generated struct, so the
+field is concretely typed at the instance level. This preserves inference when
+the sub-specifier is forwarded to a downstream API
+(e.g. `solve(...; verbose = outer.linear_verbosity)`), and lets the
+outer-spec-defining package hold a sub-specifier type that it does not depend
+on at definition time (e.g. DiffEqBase holding a NonlinearVerbosity without
+depending on NonlinearSolve).
 
-**presets:** Named tuple mapping preset names to field configurations. Each preset maps
-field names to message levels, presets, or specifier instances.
-Must include at least `Standard`. Can define custom presets beyond the standard five
-(None, Minimal, Standard, Detailed, All).
+**presets:** Named tuple mapping preset names to field configurations. Each
+preset maps field names to message levels (for toggles) or to a preset/sub-spec
+instance (for sub_specifiers). Must include at least `Standard`. Can define
+custom presets beyond the standard five (None, Minimal, Standard, Detailed, All).
 
-**groups:** Named tuple mapping group names to tuples of field symbols. Groups allow
-setting multiple fields at once.
+**groups:** Named tuple mapping group names to tuples of toggle symbols. Groups
+allow setting multiple toggles at once. Group fields must be toggles, not
+sub_specifiers.
 
 # Generated Code
 
 **Struct:** Creates `name{Enabled, S1, ..., Sk} <: AbstractVerbositySpecifier{Enabled}`,
-where `S1..Sk` are the type parameters for each declared specifier (in order). Toggle
-fields are `::MessageLevel`. If no specifiers block is given, the struct is just
-`name{Enabled}` and toggle fields use a wider Union for backward compatibility.
+where `S1..Sk` are the type parameters for each declared sub_specifier (in
+order). Toggle fields are `::MessageLevel`. If no `sub_specifiers` block is
+given, the struct is just `name{Enabled}`.
 
 **Constructors:**
 - `name()`: Default constructor using Standard preset
@@ -49,7 +53,7 @@ fields are `::MessageLevel`. If no specifiers block is given, the struct is just
 @verbosity_specifier SolverVerbosity begin
     toggles = (:convergence, :step_rejected)
 
-    specifiers = (:linear_verbosity,)
+    sub_specifiers = (:linear_verbosity,)
 
     presets = (
         Standard = (
@@ -67,7 +71,7 @@ end
 """
 macro verbosity_specifier(name, block)
     local toggles_expr = nothing
-    local specifiers_expr = nothing
+    local sub_specifiers_expr = nothing
     local presets_expr = nothing
     local groups_expr = nothing
 
@@ -78,8 +82,8 @@ macro verbosity_specifier(name, block)
                 rhs = ex.args[2]
                 if lhs == :toggles
                     toggles_expr = rhs
-                elseif lhs == :specifiers
-                    specifiers_expr = rhs
+                elseif lhs == :sub_specifiers
+                    sub_specifiers_expr = rhs
                 elseif lhs == :presets
                     presets_expr = rhs
                 elseif lhs == :groups
@@ -96,14 +100,14 @@ macro verbosity_specifier(name, block)
     toggles_expr.head == :tuple || throw(ArgumentError("toggles must be a tuple"))
     toggles = [t.value for t in toggles_expr.args]
 
-    specifiers = if specifiers_expr !== nothing
-        specifiers_expr.head == :tuple || throw(ArgumentError("specifiers must be a tuple"))
-        [t.value for t in specifiers_expr.args]
+    sub_specifiers = if sub_specifiers_expr !== nothing
+        sub_specifiers_expr.head == :tuple || throw(ArgumentError("sub_specifiers must be a tuple"))
+        [t.value for t in sub_specifiers_expr.args]
     else
         Symbol[]
     end
 
-    all_fields = [toggles; specifiers]
+    all_fields = [toggles; sub_specifiers]
 
     presets_expr.head == :tuple || throw(ArgumentError("presets must be a NamedTuple"))
     presets_dict = Dict()
@@ -137,25 +141,15 @@ macro verbosity_specifier(name, block)
     custom_presets = filter(p -> !(p in standard_presets), preset_names)
     custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
 
-    # If specifiers section is declared, toggles get concrete ::MessageLevel fields
-    # and each specifier gets its own type parameter, so the field type is concrete
-    # for whatever instance the user plugs in (a sub-specifier from another package,
-    # or a preset). This is what lets inference flow through `outer.inner` into
-    # downstream APIs without the tail of LinearCache-style parameter chains
-    # collapsing into existentials.
-    #
-    # If no specifiers section, all fields use the wider Union for backward compatibility.
-    has_specifiers = specifiers_expr !== nothing
-    spec_type_params = has_specifiers ?
-        [Symbol("__SPEC_T_", i) for i in 1:length(specifiers)] :
-        Symbol[]
-    toggle_field_type = has_specifiers ?
-        :(SciMLLogging.MessageLevel) :
-        :(Union{SciMLLogging.MessageLevel, SciMLLogging.AbstractVerbosityPreset, SciMLLogging.AbstractVerbositySpecifier})
-    toggle_fields = [:($(t)::$toggle_field_type) for t in toggles]
-    specifier_fields = has_specifiers ?
-        [:($(s)::$(spec_type_params[i])) for (i, s) in enumerate(specifiers)] :
-        Expr[]
+    # Toggle fields are always concretely typed `::MessageLevel`. Each declared
+    # sub_specifier gets its own type parameter on the generated struct, so the
+    # field is concretely typed for whatever instance the user plugs in (a
+    # sub-specifier from another package, or a preset). This is what lets
+    # inference flow through `outer.inner` into downstream APIs without the
+    # tail of LinearCache-style parameter chains collapsing into existentials.
+    spec_type_params = [Symbol("__SPEC_T_", i) for i in 1:length(sub_specifiers)]
+    toggle_fields = [:($(t)::SciMLLogging.MessageLevel) for t in toggles]
+    specifier_fields = [:($(s)::$(spec_type_params[i])) for (i, s) in enumerate(sub_specifiers)]
     struct_fields = [toggle_fields; specifier_fields]
 
     struct_type_params = [:Enabled; spec_type_params]
@@ -165,16 +159,13 @@ macro verbosity_specifier(name, block)
         end
     )
 
-    # When specifiers are present, the auto-generated constructor requires all type
-    # parameters. Add a partial-application outer constructor that takes only Enabled
-    # and lets Julia infer the specifier types from the arg types — so call sites
-    # everywhere can write `$name{true}(...)`.
-    # Skip if the specifiers tuple is declared empty: then the struct has no extra
-    # type params and the auto-generated `name{Enabled}(...)` already exists, so
-    # emitting our own would shadow it and infinite-recurse.
-    partial_app_ctor = if has_specifiers && !isempty(specifiers)
+    # When sub_specifiers are present, the auto-generated constructor requires
+    # all type parameters. Add a partial-application outer constructor that
+    # takes only Enabled and lets Julia infer the sub-specifier types from the
+    # arg types — so call sites everywhere can write `$name{true}(...)`.
+    partial_app_ctor = if !isempty(sub_specifiers)
         all_arg_names = [Symbol("__arg_", f) for f in all_fields]
-        typeof_specs = [:(typeof($(Symbol("__arg_", s)))) for s in specifiers]
+        typeof_specs = [:(typeof($(Symbol("__arg_", s)))) for s in sub_specifiers]
         :(
             function $name{Enabled}($(all_arg_names...)) where {Enabled}
                 return $name{Enabled, $(typeof_specs...)}($(all_arg_names...))
@@ -219,11 +210,11 @@ macro verbosity_specifier(name, block)
     for group_name in group_names
         lazy_str = Expr(
             :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
-            "\$($(QuoteNode(group_name))) must be a SciMLLogging.AbstractMessageLevel, got \$(typeof($(group_name)))"
+            "\$($(QuoteNode(group_name))) must be a SciMLLogging.MessageLevel, got \$(typeof($(group_name)))"
         )
         push!(
             group_validations, quote
-                if $(group_name) !== nothing && !($(group_name) isa AbstractMessageLevel)
+                if $(group_name) !== nothing && !($(group_name) isa MessageLevel)
                     throw(ArgumentError($lazy_str))
                 end
             end
@@ -261,17 +252,13 @@ macro verbosity_specifier(name, block)
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
         "Unknown verbosity option: \$key. Valid options are: $(Tuple(all_fields))"
     )
-    invalid_type_str = Expr(
-        :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
-        "\$key must be a SciMLLogging.MessageLevel, AbstractVerbosityPreset, or AbstractVerbositySpecifier, got \$(typeof(value))"
-    )
     toggle_type_str = Expr(
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
         "\$key is a toggle and must be a SciMLLogging.MessageLevel, got \$(typeof(value))"
     )
-    specifier_type_str = Expr(
+    sub_specifier_type_str = Expr(
         :macrocall, Symbol("@lazy_str"), LineNumberNode(@__LINE__, @__FILE__),
-        "\$key is a specifier field and must be a SciMLLogging.AbstractVerbositySpecifier or AbstractVerbosityPreset, got \$(typeof(value))"
+        "\$key is a sub_specifier field and must be a SciMLLogging.AbstractVerbositySpecifier or AbstractVerbosityPreset, got \$(typeof(value))"
     )
 
     main_constructor = quote
@@ -290,15 +277,10 @@ macro verbosity_specifier(name, block)
 
             for (key, value) in pairs(kwargs)
                 if key in $(Tuple(toggles))
-                    if $(specifiers_expr !== nothing)
-                        !(value isa MessageLevel) && throw(ArgumentError($toggle_type_str))
-                    else
-                        !(value isa AbstractMessageLevel || value isa AbstractVerbosityPreset || value isa AbstractVerbositySpecifier) &&
-                            throw(ArgumentError($invalid_type_str))
-                    end
-                elseif key in $(Tuple(specifiers))
+                    !(value isa MessageLevel) && throw(ArgumentError($toggle_type_str))
+                elseif key in $(Tuple(sub_specifiers))
                     !(value isa AbstractVerbositySpecifier || value isa AbstractVerbosityPreset) &&
-                        throw(ArgumentError($specifier_type_str))
+                        throw(ArgumentError($sub_specifier_type_str))
                 else
                     throw(ArgumentError($unknown_option_str))
                 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -12,21 +12,21 @@ struct TestVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
 end
 
 function TestVerbosity(;
-        test1 = WarnLevel(),
-        test2 = InfoLevel(),
-        test3 = ErrorLevel(),
-        test4 = Silent()
+        test1 = WarnLevel,
+        test2 = InfoLevel,
+        test3 = ErrorLevel,
+        test4 = Silent
     )
     return TestVerbosity{true}(test1, test2, test3, test4)
 end
 
 function TestVerbosity(preset::AbstractVerbosityPreset)
     return if preset isa SciMLLogging.None
-        TestVerbosity{false}(Silent(), Silent(), Silent(), Silent())
+        TestVerbosity{false}(Silent, Silent, Silent, Silent)
     elseif preset isa SciMLLogging.All
-        TestVerbosity{true}(InfoLevel(), InfoLevel(), InfoLevel(), InfoLevel())
+        TestVerbosity{true}(InfoLevel, InfoLevel, InfoLevel, InfoLevel)
     elseif preset isa Minimal
-        TestVerbosity{true}(ErrorLevel(), Silent(), ErrorLevel(), Silent())
+        TestVerbosity{true}(ErrorLevel, Silent, ErrorLevel, Silent)
     else
         TestVerbosity()
     end
@@ -78,10 +78,10 @@ end
 
 @testset "Disabled verbosity" begin
     verbose_off = TestVerbosity(
-        test1 = Silent(),
-        test2 = Silent(),
-        test3 = Silent(),
-        test4 = Silent()
+        test1 = Silent,
+        test2 = Silent,
+        test3 = Silent,
+        test4 = Silent
     )
 
     # Should not log anything when all categories are silent
@@ -182,7 +182,7 @@ end
     )
 
     # Test that silent still skips emission even with varargs
-    verbose_silent = TestVerbosity(test1 = Silent())
+    verbose_silent = TestVerbosity(test1 = Silent)
     @test_logs min_level = Logging.Debug @SciMLMessage(
         "Should not appear", verbose_silent, :test1, x, y
     )

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,5 +1,5 @@
 using SciMLLogging
-using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, AbstractVerbosityPreset, MessageLevel, AbstractMessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All, Minimal
+using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, AbstractVerbosityPreset, MessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All, Minimal
 using Logging
 using Test
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,47 +1,32 @@
 using SciMLLogging
-using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, AbstractVerbosityPreset, AbstractMessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All, Minimal
+using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage, AbstractVerbosityPreset, MessageLevel, AbstractMessageLevel, WarnLevel, InfoLevel, ErrorLevel, Silent, None, All, Minimal
 using Logging
 using Test
 
 # Structs for testing package - simplified structure
-struct TestVerbosity <: AbstractVerbositySpecifier
-    test1
-    test2
-    test3
-    test4
+struct TestVerbosity{Enabled} <: AbstractVerbositySpecifier{Enabled}
+    test1::MessageLevel
+    test2::MessageLevel
+    test3::MessageLevel
+    test4::MessageLevel
+end
 
-    function TestVerbosity(;
-            test1 = WarnLevel(),
-            test2 = InfoLevel(),
-            test3 = ErrorLevel(),
-            test4 = Silent()
-        )
-        return new(test1, test2, test3, test4)
-    end
+function TestVerbosity(;
+        test1 = WarnLevel(),
+        test2 = InfoLevel(),
+        test3 = ErrorLevel(),
+        test4 = Silent()
+    )
+    return TestVerbosity{true}(test1, test2, test3, test4)
 end
 
 function TestVerbosity(preset::AbstractVerbosityPreset)
     return if preset isa SciMLLogging.None
-        TestVerbosity(
-            test1 = Silent(),
-            test2 = Silent(),
-            test3 = Silent(),
-            test4 = Silent()
-        )
+        TestVerbosity{false}(Silent(), Silent(), Silent(), Silent())
     elseif preset isa SciMLLogging.All
-        TestVerbosity(
-            test1 = InfoLevel(),
-            test2 = InfoLevel(),
-            test3 = InfoLevel(),
-            test4 = InfoLevel()
-        )
+        TestVerbosity{true}(InfoLevel(), InfoLevel(), InfoLevel(), InfoLevel())
     elseif preset isa Minimal
-        TestVerbosity(
-            test1 = ErrorLevel(),
-            test2 = Silent(),
-            test3 = ErrorLevel(),
-            test4 = Silent()
-        )
+        TestVerbosity{true}(ErrorLevel(), Silent(), ErrorLevel(), Silent())
     else
         TestVerbosity()
     end

--- a/test/generation_test.jl
+++ b/test/generation_test.jl
@@ -13,64 +13,64 @@ SciMLLogging.@verbosity_specifier VerbSpec begin
 
     presets = (
         None = (
-            toggle1 = Silent(),
-            toggle2 = Silent(),
-            toggle3 = Silent(),
-            toggle4 = Silent(),
-            toggle5 = Silent(),
-            toggle6 = Silent(),
-            toggle7 = Silent(),
-            toggle8 = Silent(),
-            toggle9 = Silent(),
-            toggle10 = Silent(),
+            toggle1 = Silent,
+            toggle2 = Silent,
+            toggle3 = Silent,
+            toggle4 = Silent,
+            toggle5 = Silent,
+            toggle6 = Silent,
+            toggle7 = Silent,
+            toggle8 = Silent,
+            toggle9 = Silent,
+            toggle10 = Silent,
         ),
         Minimal = (
-            toggle1 = WarnLevel(),
-            toggle2 = Silent(),
-            toggle3 = ErrorLevel(),
-            toggle4 = DebugLevel(),
-            toggle5 = InfoLevel(),
-            toggle6 = WarnLevel(),
-            toggle7 = Silent(),
-            toggle8 = InfoLevel(),
-            toggle9 = DebugLevel(),
-            toggle10 = ErrorLevel(),
+            toggle1 = WarnLevel,
+            toggle2 = Silent,
+            toggle3 = ErrorLevel,
+            toggle4 = DebugLevel,
+            toggle5 = InfoLevel,
+            toggle6 = WarnLevel,
+            toggle7 = Silent,
+            toggle8 = InfoLevel,
+            toggle9 = DebugLevel,
+            toggle10 = ErrorLevel,
         ),
         Standard = (
-            toggle1 = InfoLevel(),
-            toggle2 = WarnLevel(),
-            toggle3 = DebugLevel(),
-            toggle4 = ErrorLevel(),
-            toggle5 = Silent(),
-            toggle6 = InfoLevel(),
-            toggle7 = DebugLevel(),
-            toggle8 = WarnLevel(),
-            toggle9 = Silent(),
-            toggle10 = ErrorLevel(),
+            toggle1 = InfoLevel,
+            toggle2 = WarnLevel,
+            toggle3 = DebugLevel,
+            toggle4 = ErrorLevel,
+            toggle5 = Silent,
+            toggle6 = InfoLevel,
+            toggle7 = DebugLevel,
+            toggle8 = WarnLevel,
+            toggle9 = Silent,
+            toggle10 = ErrorLevel,
         ),
         Detailed = (
-            toggle1 = DebugLevel(),
-            toggle2 = InfoLevel(),
-            toggle3 = Silent(),
-            toggle4 = WarnLevel(),
-            toggle5 = ErrorLevel(),
-            toggle6 = DebugLevel(),
-            toggle7 = ErrorLevel(),
-            toggle8 = Silent(),
-            toggle9 = WarnLevel(),
-            toggle10 = InfoLevel(),
+            toggle1 = DebugLevel,
+            toggle2 = InfoLevel,
+            toggle3 = Silent,
+            toggle4 = WarnLevel,
+            toggle5 = ErrorLevel,
+            toggle6 = DebugLevel,
+            toggle7 = ErrorLevel,
+            toggle8 = Silent,
+            toggle9 = WarnLevel,
+            toggle10 = InfoLevel,
         ),
         All = (
-            toggle1 = ErrorLevel(),
-            toggle2 = DebugLevel(),
-            toggle3 = InfoLevel(),
-            toggle4 = Silent(),
-            toggle5 = WarnLevel(),
-            toggle6 = ErrorLevel(),
-            toggle7 = InfoLevel(),
-            toggle8 = DebugLevel(),
-            toggle9 = WarnLevel(),
-            toggle10 = Silent(),
+            toggle1 = ErrorLevel,
+            toggle2 = DebugLevel,
+            toggle3 = InfoLevel,
+            toggle4 = Silent,
+            toggle5 = WarnLevel,
+            toggle6 = ErrorLevel,
+            toggle7 = InfoLevel,
+            toggle8 = DebugLevel,
+            toggle9 = WarnLevel,
+            toggle10 = Silent,
         ),
     )
 
@@ -85,126 +85,126 @@ end
     # Test 1: Default constructor (no arguments) - should use Standard preset
     @testset "Default constructor" begin
         v = VerbSpec()
-        @test v.toggle1 == InfoLevel()
-        @test v.toggle2 == WarnLevel()
-        @test v.toggle3 == DebugLevel()
-        @test v.toggle10 == ErrorLevel()
+        @test v.toggle1 == InfoLevel
+        @test v.toggle2 == WarnLevel
+        @test v.toggle3 == DebugLevel
+        @test v.toggle10 == ErrorLevel
     end
 
     # Test 2: Preset constructors
     @testset "Preset constructors" begin
         # None preset
         v_none = VerbSpec(None())
-        @test all(getfield(v_none, f) == Silent() for f in fieldnames(typeof(v_none)))
+        @test all(getfield(v_none, f) == Silent for f in fieldnames(typeof(v_none)))
 
         # Minimal preset
         v_min = VerbSpec(Minimal())
-        @test v_min.toggle1 == WarnLevel()
-        @test v_min.toggle2 == Silent()
-        @test v_min.toggle3 == ErrorLevel()
+        @test v_min.toggle1 == WarnLevel
+        @test v_min.toggle2 == Silent
+        @test v_min.toggle3 == ErrorLevel
 
         # Standard preset
         v_std = VerbSpec(Standard())
-        @test v_std.toggle1 == InfoLevel()
-        @test v_std.toggle2 == WarnLevel()
+        @test v_std.toggle1 == InfoLevel
+        @test v_std.toggle2 == WarnLevel
 
         # Detailed preset
         v_det = VerbSpec(Detailed())
-        @test v_det.toggle1 == DebugLevel()
-        @test v_det.toggle2 == InfoLevel()
+        @test v_det.toggle1 == DebugLevel
+        @test v_det.toggle2 == InfoLevel
 
         # All preset
         v_all = VerbSpec(All())
-        @test v_all.toggle1 == ErrorLevel()
-        @test v_all.toggle2 == DebugLevel()
+        @test v_all.toggle1 == ErrorLevel
+        @test v_all.toggle2 == DebugLevel
     end
 
     # Test 3: Keyword constructor with preset parameter
     @testset "Keyword constructor with preset" begin
         v = VerbSpec(preset = Minimal())
-        @test v.toggle1 == WarnLevel()
-        @test v.toggle2 == Silent()
+        @test v.toggle1 == WarnLevel
+        @test v.toggle2 == Silent
     end
 
     # Test 4: Group parameters
     @testset "Group parameters" begin
         # Set all numerical toggles to ErrorLevel
-        v = VerbSpec(numerical = ErrorLevel())
-        @test v.toggle1 == ErrorLevel()  # numerical group
-        @test v.toggle2 == ErrorLevel()  # numerical group
-        @test v.toggle3 == ErrorLevel()  # numerical group
-        @test v.toggle4 == ErrorLevel()  # performance group (from Standard preset)
+        v = VerbSpec(numerical = ErrorLevel)
+        @test v.toggle1 == ErrorLevel  # numerical group
+        @test v.toggle2 == ErrorLevel  # numerical group
+        @test v.toggle3 == ErrorLevel  # numerical group
+        @test v.toggle4 == ErrorLevel  # performance group (from Standard preset)
 
         # Set all performance toggles
-        v2 = VerbSpec(performance = InfoLevel())
-        @test v2.toggle4 == InfoLevel()  # performance group
-        @test v2.toggle5 == InfoLevel()  # performance group
-        @test v2.toggle6 == InfoLevel()  # performance group
-        @test v2.toggle7 == InfoLevel()  # performance group
+        v2 = VerbSpec(performance = InfoLevel)
+        @test v2.toggle4 == InfoLevel  # performance group
+        @test v2.toggle5 == InfoLevel  # performance group
+        @test v2.toggle6 == InfoLevel  # performance group
+        @test v2.toggle7 == InfoLevel  # performance group
 
         # Set all error_control toggles
-        v3 = VerbSpec(error_control = DebugLevel())
-        @test v3.toggle8 == DebugLevel()  # error_control group
-        @test v3.toggle9 == DebugLevel()  # error_control group
-        @test v3.toggle10 == DebugLevel()  # error_control group
+        v3 = VerbSpec(error_control = DebugLevel)
+        @test v3.toggle8 == DebugLevel  # error_control group
+        @test v3.toggle9 == DebugLevel  # error_control group
+        @test v3.toggle10 == DebugLevel  # error_control group
     end
 
     # Test 5: Individual toggle parameters
     @testset "Individual toggle parameters" begin
-        v = VerbSpec(toggle1 = ErrorLevel())
-        @test v.toggle1 == ErrorLevel()
-        @test v.toggle2 == WarnLevel()  # from Standard preset
+        v = VerbSpec(toggle1 = ErrorLevel)
+        @test v.toggle1 == ErrorLevel
+        @test v.toggle2 == WarnLevel  # from Standard preset
 
         # Multiple individual toggles
-        v2 = VerbSpec(toggle1 = ErrorLevel(), toggle5 = WarnLevel())
-        @test v2.toggle1 == ErrorLevel()
-        @test v2.toggle5 == WarnLevel()
+        v2 = VerbSpec(toggle1 = ErrorLevel, toggle5 = WarnLevel)
+        @test v2.toggle1 == ErrorLevel
+        @test v2.toggle5 == WarnLevel
     end
 
     # Test 6: Precedence: individual > group > preset
     @testset "Precedence tests" begin
         # Individual overrides group
-        v = VerbSpec(numerical = WarnLevel(), toggle1 = ErrorLevel())
-        @test v.toggle1 == ErrorLevel()  # individual wins
-        @test v.toggle2 == WarnLevel()   # from group
-        @test v.toggle3 == WarnLevel()   # from group
+        v = VerbSpec(numerical = WarnLevel, toggle1 = ErrorLevel)
+        @test v.toggle1 == ErrorLevel  # individual wins
+        @test v.toggle2 == WarnLevel   # from group
+        @test v.toggle3 == WarnLevel   # from group
 
         # Group overrides preset
-        v2 = VerbSpec(preset = None(), numerical = InfoLevel())
-        @test v2.toggle1 == InfoLevel()  # from group
-        @test v2.toggle4 == Silent()     # from preset (not in numerical group)
+        v2 = VerbSpec(preset = None(), numerical = InfoLevel)
+        @test v2.toggle1 == InfoLevel  # from group
+        @test v2.toggle4 == Silent     # from preset (not in numerical group)
 
         # All three levels
-        v3 = VerbSpec(preset = None(), performance = WarnLevel(), toggle4 = ErrorLevel())
-        @test v3.toggle4 == ErrorLevel()  # individual wins
-        @test v3.toggle5 == WarnLevel()   # from group
-        @test v3.toggle1 == Silent()      # from preset
+        v3 = VerbSpec(preset = None(), performance = WarnLevel, toggle4 = ErrorLevel)
+        @test v3.toggle4 == ErrorLevel  # individual wins
+        @test v3.toggle5 == WarnLevel   # from group
+        @test v3.toggle1 == Silent      # from preset
     end
 
     # Test 7: Combining preset with groups
     @testset "Preset with groups" begin
-        v = VerbSpec(preset = Minimal(), numerical = DebugLevel())
-        @test v.toggle1 == DebugLevel()  # from group
-        @test v.toggle2 == DebugLevel()  # from group
-        @test v.toggle3 == DebugLevel()  # from group
-        @test v.toggle4 == DebugLevel()  # from Minimal preset
+        v = VerbSpec(preset = Minimal(), numerical = DebugLevel)
+        @test v.toggle1 == DebugLevel  # from group
+        @test v.toggle2 == DebugLevel  # from group
+        @test v.toggle3 == DebugLevel  # from group
+        @test v.toggle4 == DebugLevel  # from Minimal preset
     end
 
     # Test 8: All three: preset, groups, and individual toggles
     @testset "Preset + groups + individual toggles" begin
         v = VerbSpec(
             preset = Detailed(),
-            numerical = ErrorLevel(),
-            performance = WarnLevel(),
-            toggle1 = InfoLevel(),
-            toggle4 = DebugLevel()
+            numerical = ErrorLevel,
+            performance = WarnLevel,
+            toggle1 = InfoLevel,
+            toggle4 = DebugLevel
         )
-        @test v.toggle1 == InfoLevel()   # individual wins
-        @test v.toggle2 == ErrorLevel()  # from numerical group
-        @test v.toggle3 == ErrorLevel()  # from numerical group
-        @test v.toggle4 == DebugLevel()  # individual wins
-        @test v.toggle5 == WarnLevel()   # from performance group
-        @test v.toggle8 == Silent()      # from Detailed preset
+        @test v.toggle1 == InfoLevel   # individual wins
+        @test v.toggle2 == ErrorLevel  # from numerical group
+        @test v.toggle3 == ErrorLevel  # from numerical group
+        @test v.toggle4 == DebugLevel  # individual wins
+        @test v.toggle5 == WarnLevel   # from performance group
+        @test v.toggle8 == Silent      # from Detailed preset
     end
 
     # Test 9: Type stability - ensure parametric types work
@@ -223,7 +223,7 @@ end
         @test_throws ArgumentError VerbSpec(toggle1 = "invalid")
 
         # Unknown toggle name
-        @test_throws ArgumentError VerbSpec(unknown_toggle = ErrorLevel())
+        @test_throws ArgumentError VerbSpec(unknown_toggle = ErrorLevel)
 
         # Invalid preset type
         @test_throws ArgumentError VerbSpec(preset = "invalid")
@@ -254,94 +254,94 @@ end
 
     presets = (
         None = (
-            default_lu_fallback = Silent(),
-            no_right_preconditioning = Silent(),
-            using_IterativeSolvers = Silent(),
-            IterativeSolvers_iterations = Silent(),
-            KrylovKit_verbosity = Silent(),
-            KrylovJL_verbosity = Silent(),
-            HYPRE_verbosity = Silent(),
-            pardiso_verbosity = Silent(),
-            blas_errors = Silent(),
-            blas_invalid_args = Silent(),
-            blas_info = Silent(),
-            blas_success = Silent(),
-            condition_number = Silent(),
-            convergence_failure = Silent(),
-            solver_failure = Silent(),
-            max_iters = Silent(),
+            default_lu_fallback = Silent,
+            no_right_preconditioning = Silent,
+            using_IterativeSolvers = Silent,
+            IterativeSolvers_iterations = Silent,
+            KrylovKit_verbosity = Silent,
+            KrylovJL_verbosity = Silent,
+            HYPRE_verbosity = Silent,
+            pardiso_verbosity = Silent,
+            blas_errors = Silent,
+            blas_invalid_args = Silent,
+            blas_info = Silent,
+            blas_success = Silent,
+            condition_number = Silent,
+            convergence_failure = Silent,
+            solver_failure = Silent,
+            max_iters = Silent,
         ),
         Minimal = (
-            default_lu_fallback = Silent(),
-            no_right_preconditioning = Silent(),
-            using_IterativeSolvers = Silent(),
-            IterativeSolvers_iterations = Silent(),
-            KrylovKit_verbosity = Silent(),
-            KrylovJL_verbosity = Silent(),
-            HYPRE_verbosity = Silent(),
-            pardiso_verbosity = Silent(),
-            blas_errors = WarnLevel(),
-            blas_invalid_args = WarnLevel(),
-            blas_info = Silent(),
-            blas_success = Silent(),
-            condition_number = Silent(),
-            convergence_failure = Silent(),
-            solver_failure = Silent(),
-            max_iters = Silent(),
+            default_lu_fallback = Silent,
+            no_right_preconditioning = Silent,
+            using_IterativeSolvers = Silent,
+            IterativeSolvers_iterations = Silent,
+            KrylovKit_verbosity = Silent,
+            KrylovJL_verbosity = Silent,
+            HYPRE_verbosity = Silent,
+            pardiso_verbosity = Silent,
+            blas_errors = WarnLevel,
+            blas_invalid_args = WarnLevel,
+            blas_info = Silent,
+            blas_success = Silent,
+            condition_number = Silent,
+            convergence_failure = Silent,
+            solver_failure = Silent,
+            max_iters = Silent,
         ),
         Standard = (
-            default_lu_fallback = Silent(),
-            no_right_preconditioning = Silent(),
-            using_IterativeSolvers = Silent(),
-            IterativeSolvers_iterations = Silent(),
+            default_lu_fallback = Silent,
+            no_right_preconditioning = Silent,
+            using_IterativeSolvers = Silent,
+            IterativeSolvers_iterations = Silent,
             KrylovKit_verbosity = CustomLevel(1),
-            KrylovJL_verbosity = Silent(),
-            HYPRE_verbosity = InfoLevel(),
-            pardiso_verbosity = Silent(),
-            blas_errors = WarnLevel(),
-            blas_invalid_args = WarnLevel(),
-            blas_info = Silent(),
-            blas_success = Silent(),
-            condition_number = Silent(),
-            convergence_failure = WarnLevel(),
-            solver_failure = WarnLevel(),
-            max_iters = WarnLevel(),
+            KrylovJL_verbosity = Silent,
+            HYPRE_verbosity = InfoLevel,
+            pardiso_verbosity = Silent,
+            blas_errors = WarnLevel,
+            blas_invalid_args = WarnLevel,
+            blas_info = Silent,
+            blas_success = Silent,
+            condition_number = Silent,
+            convergence_failure = WarnLevel,
+            solver_failure = WarnLevel,
+            max_iters = WarnLevel,
         ),
         Detailed = (
-            default_lu_fallback = WarnLevel(),
-            no_right_preconditioning = InfoLevel(),
-            using_IterativeSolvers = InfoLevel(),
-            IterativeSolvers_iterations = Silent(),
+            default_lu_fallback = WarnLevel,
+            no_right_preconditioning = InfoLevel,
+            using_IterativeSolvers = InfoLevel,
+            IterativeSolvers_iterations = Silent,
             KrylovKit_verbosity = CustomLevel(2),
             KrylovJL_verbosity = CustomLevel(1),
-            HYPRE_verbosity = InfoLevel(),
+            HYPRE_verbosity = InfoLevel,
             pardiso_verbosity = CustomLevel(1),
-            blas_errors = WarnLevel(),
-            blas_invalid_args = WarnLevel(),
-            blas_info = InfoLevel(),
-            blas_success = InfoLevel(),
-            condition_number = Silent(),
-            convergence_failure = WarnLevel(),
-            solver_failure = WarnLevel(),
-            max_iters = WarnLevel(),
+            blas_errors = WarnLevel,
+            blas_invalid_args = WarnLevel,
+            blas_info = InfoLevel,
+            blas_success = InfoLevel,
+            condition_number = Silent,
+            convergence_failure = WarnLevel,
+            solver_failure = WarnLevel,
+            max_iters = WarnLevel,
         ),
         All = (
-            default_lu_fallback = WarnLevel(),
-            no_right_preconditioning = InfoLevel(),
-            using_IterativeSolvers = InfoLevel(),
-            IterativeSolvers_iterations = InfoLevel(),
+            default_lu_fallback = WarnLevel,
+            no_right_preconditioning = InfoLevel,
+            using_IterativeSolvers = InfoLevel,
+            IterativeSolvers_iterations = InfoLevel,
             KrylovKit_verbosity = CustomLevel(3),
             KrylovJL_verbosity = CustomLevel(1),
-            HYPRE_verbosity = InfoLevel(),
+            HYPRE_verbosity = InfoLevel,
             pardiso_verbosity = CustomLevel(1),
-            blas_errors = WarnLevel(),
-            blas_invalid_args = WarnLevel(),
-            blas_info = InfoLevel(),
-            blas_success = InfoLevel(),
-            condition_number = InfoLevel(),
-            convergence_failure = WarnLevel(),
-            solver_failure = WarnLevel(),
-            max_iters = WarnLevel(),
+            blas_errors = WarnLevel,
+            blas_invalid_args = WarnLevel,
+            blas_info = InfoLevel,
+            blas_success = InfoLevel,
+            condition_number = InfoLevel,
+            convergence_failure = WarnLevel,
+            solver_failure = WarnLevel,
+            max_iters = WarnLevel,
         ),
     )
 
@@ -361,25 +361,25 @@ end
 @testset "LinearVerbosity Tests" begin
     @testset "Default constructor" begin
         v = LinearVerbosity()
-        @test v.blas_errors == WarnLevel()
-        @test v.default_lu_fallback == Silent()
+        @test v.blas_errors == WarnLevel
+        @test v.default_lu_fallback == Silent
         @test v.KrylovKit_verbosity == CustomLevel(1)
     end
 
     @testset "Preset constructors" begin
         v_none = LinearVerbosity(None())
-        @test all(getfield(v_none, f) == Silent() for f in fieldnames(typeof(v_none)))
+        @test all(getfield(v_none, f) == Silent for f in fieldnames(typeof(v_none)))
 
         v_min = LinearVerbosity(Minimal())
-        @test v_min.blas_errors == WarnLevel()
-        @test v_min.convergence_failure == Silent()
+        @test v_min.blas_errors == WarnLevel
+        @test v_min.convergence_failure == Silent
     end
 
     @testset "Group parameters" begin
-        v = LinearVerbosity(error_control = ErrorLevel())
-        @test v.default_lu_fallback == ErrorLevel()
-        @test v.blas_errors == ErrorLevel()
-        @test v.blas_invalid_args == ErrorLevel()
+        v = LinearVerbosity(error_control = ErrorLevel)
+        @test v.default_lu_fallback == ErrorLevel
+        @test v.blas_errors == ErrorLevel
+        @test v.blas_invalid_args == ErrorLevel
     end
 end
 
@@ -392,29 +392,29 @@ end
 
     presets = (
         None = (
-            component_a = Silent(),
+            component_a = Silent,
             component_b = None(),
-            component_c = Silent(),
+            component_c = Silent,
         ),
         Minimal = (
-            component_a = WarnLevel(),
+            component_a = WarnLevel,
             component_b = Minimal(),
-            component_c = InfoLevel(),
+            component_c = InfoLevel,
         ),
         Standard = (
-            component_a = InfoLevel(),
+            component_a = InfoLevel,
             component_b = Standard(),
-            component_c = WarnLevel(),
+            component_c = WarnLevel,
         ),
         Detailed = (
-            component_a = DebugLevel(),
+            component_a = DebugLevel,
             component_b = Detailed(),
-            component_c = InfoLevel(),
+            component_c = InfoLevel,
         ),
         All = (
-            component_a = ErrorLevel(),
+            component_a = ErrorLevel,
             component_b = All(),
-            component_c = DebugLevel(),
+            component_c = DebugLevel,
         ),
     )
 
@@ -427,28 +427,28 @@ end
 @testset "HierarchicalVerbosity with Preset References" begin
     @testset "Preset as sub_specifier value" begin
         v = HierarchicalVerbosity(preset = Minimal())
-        @test v.component_a == WarnLevel()
+        @test v.component_a == WarnLevel
         @test v.component_b == Minimal()  # Should be the preset type, not expanded
-        @test v.component_c == InfoLevel()
+        @test v.component_c == InfoLevel
 
         v2 = HierarchicalVerbosity(preset = Standard())
-        @test v2.component_a == InfoLevel()
+        @test v2.component_a == InfoLevel
         @test v2.component_b == Standard()
-        @test v2.component_c == WarnLevel()
+        @test v2.component_c == WarnLevel
     end
 
     @testset "Override sub_specifier with another preset" begin
         v = HierarchicalVerbosity(preset = Standard(), component_b = Detailed())
-        @test v.component_a == InfoLevel()
+        @test v.component_a == InfoLevel
         @test v.component_b == Detailed()  # Overridden
-        @test v.component_c == WarnLevel()
+        @test v.component_c == WarnLevel
     end
 
     @testset "Set sub_specifier to preset via kwarg" begin
-        v = HierarchicalVerbosity(component_a = InfoLevel(), component_b = Detailed())
-        @test v.component_a == InfoLevel()
+        v = HierarchicalVerbosity(component_a = InfoLevel, component_b = Detailed())
+        @test v.component_a == InfoLevel
         @test v.component_b == Detailed()  # Set to preset type via kwarg
-        @test v.component_c == WarnLevel()  # From Standard preset (default)
+        @test v.component_c == WarnLevel  # From Standard preset (default)
     end
 end
 
@@ -458,40 +458,40 @@ end
 
     presets = (
         None = (
-            solver = Silent(),
-            preconditioner = Silent(),
-            convergence = Silent(),
+            solver = Silent,
+            preconditioner = Silent,
+            convergence = Silent,
         ),
         Minimal = (
-            solver = WarnLevel(),
-            preconditioner = Silent(),
-            convergence = WarnLevel(),
+            solver = WarnLevel,
+            preconditioner = Silent,
+            convergence = WarnLevel,
         ),
         Standard = (
-            solver = InfoLevel(),
-            preconditioner = InfoLevel(),
-            convergence = WarnLevel(),
+            solver = InfoLevel,
+            preconditioner = InfoLevel,
+            convergence = WarnLevel,
         ),
         Detailed = (
-            solver = DebugLevel(),
-            preconditioner = InfoLevel(),
-            convergence = InfoLevel(),
+            solver = DebugLevel,
+            preconditioner = InfoLevel,
+            convergence = InfoLevel,
         ),
         All = (
-            solver = DebugLevel(),
-            preconditioner = DebugLevel(),
-            convergence = DebugLevel(),
+            solver = DebugLevel,
+            preconditioner = DebugLevel,
+            convergence = DebugLevel,
         ),
         # Custom presets
         QuietSolver = (
-            solver = Silent(),
-            preconditioner = InfoLevel(),
-            convergence = WarnLevel(),
+            solver = Silent,
+            preconditioner = InfoLevel,
+            convergence = WarnLevel,
         ),
         VerboseSolver = (
-            solver = DebugLevel(),
-            preconditioner = Silent(),
-            convergence = ErrorLevel(),
+            solver = DebugLevel,
+            preconditioner = Silent,
+            convergence = ErrorLevel,
         ),
     )
 
@@ -504,37 +504,37 @@ end
 @testset "CustomPresetVerbosity with Custom Presets" begin
     @testset "Standard presets work" begin
         v = CustomPresetVerbosity(preset = Standard())
-        @test v.solver == InfoLevel()
-        @test v.preconditioner == InfoLevel()
-        @test v.convergence == WarnLevel()
+        @test v.solver == InfoLevel
+        @test v.preconditioner == InfoLevel
+        @test v.convergence == WarnLevel
     end
 
     @testset "Custom preset QuietSolver" begin
         v = CustomPresetVerbosity(preset = QuietSolver())
-        @test v.solver == Silent()
-        @test v.preconditioner == InfoLevel()
-        @test v.convergence == WarnLevel()
+        @test v.solver == Silent
+        @test v.preconditioner == InfoLevel
+        @test v.convergence == WarnLevel
     end
 
     @testset "Custom preset VerboseSolver" begin
         v = CustomPresetVerbosity(preset = VerboseSolver())
-        @test v.solver == DebugLevel()
-        @test v.preconditioner == Silent()
-        @test v.convergence == ErrorLevel()
+        @test v.solver == DebugLevel
+        @test v.preconditioner == Silent
+        @test v.convergence == ErrorLevel
     end
 
     @testset "Override custom preset with group" begin
-        v = CustomPresetVerbosity(preset = QuietSolver(), core = ErrorLevel())
-        @test v.solver == ErrorLevel()  # Overridden by group
-        @test v.preconditioner == ErrorLevel()  # Overridden by group
-        @test v.convergence == WarnLevel()  # From preset
+        v = CustomPresetVerbosity(preset = QuietSolver(), core = ErrorLevel)
+        @test v.solver == ErrorLevel  # Overridden by group
+        @test v.preconditioner == ErrorLevel  # Overridden by group
+        @test v.convergence == WarnLevel  # From preset
     end
 
     @testset "Override custom preset with individual toggle" begin
-        v = CustomPresetVerbosity(preset = VerboseSolver(), solver = InfoLevel())
-        @test v.solver == InfoLevel()  # Overridden
-        @test v.preconditioner == Silent()  # From preset
-        @test v.convergence == ErrorLevel()  # From preset
+        v = CustomPresetVerbosity(preset = VerboseSolver(), solver = InfoLevel)
+        @test v.solver == InfoLevel  # Overridden
+        @test v.preconditioner == Silent  # From preset
+        @test v.convergence == ErrorLevel  # From preset
     end
 end
 
@@ -543,11 +543,11 @@ end
     toggles = (:inner_a, :inner_b)
 
     presets = (
-        None = (inner_a = Silent(), inner_b = Silent()),
-        Minimal = (inner_a = WarnLevel(), inner_b = Silent()),
-        Standard = (inner_a = InfoLevel(), inner_b = WarnLevel()),
-        Detailed = (inner_a = DebugLevel(), inner_b = InfoLevel()),
-        All = (inner_a = DebugLevel(), inner_b = DebugLevel()),
+        None = (inner_a = Silent, inner_b = Silent),
+        Minimal = (inner_a = WarnLevel, inner_b = Silent),
+        Standard = (inner_a = InfoLevel, inner_b = WarnLevel),
+        Detailed = (inner_a = DebugLevel, inner_b = InfoLevel),
+        All = (inner_a = DebugLevel, inner_b = DebugLevel),
     )
 
     groups = ()
@@ -561,28 +561,28 @@ end
 
     presets = (
         None = (
-            outer_a = Silent(),
-            outer_b = Silent(),
+            outer_a = Silent,
+            outer_b = Silent,
             inner = InnerVerb(None()),
         ),
         Minimal = (
-            outer_a = WarnLevel(),
-            outer_b = Silent(),
+            outer_a = WarnLevel,
+            outer_b = Silent,
             inner = InnerVerb(Minimal()),
         ),
         Standard = (
-            outer_a = InfoLevel(),
-            outer_b = WarnLevel(),
+            outer_a = InfoLevel,
+            outer_b = WarnLevel,
             inner = InnerVerb(Standard()),
         ),
         Detailed = (
-            outer_a = DebugLevel(),
-            outer_b = InfoLevel(),
+            outer_a = DebugLevel,
+            outer_b = InfoLevel,
             inner = InnerVerb(Detailed()),
         ),
         All = (
-            outer_a = DebugLevel(),
-            outer_b = DebugLevel(),
+            outer_a = DebugLevel,
+            outer_b = DebugLevel,
             inner = InnerVerb(All()),
         ),
     )
@@ -611,56 +611,56 @@ end
 
     @testset "Default constructor" begin
         v = OuterVerb()
-        @test v.outer_a == InfoLevel()
-        @test v.outer_b == WarnLevel()
+        @test v.outer_a == InfoLevel
+        @test v.outer_b == WarnLevel
         @test v.inner isa InnerVerb
-        @test v.inner.inner_a == InfoLevel()
-        @test v.inner.inner_b == WarnLevel()
+        @test v.inner.inner_a == InfoLevel
+        @test v.inner.inner_b == WarnLevel
     end
 
     @testset "Preset constructors set both toggles and sub_specifiers" begin
         v_none = OuterVerb(None())
-        @test v_none.outer_a == Silent()
-        @test v_none.outer_b == Silent()
+        @test v_none.outer_a == Silent
+        @test v_none.outer_b == Silent
         @test v_none.inner isa InnerVerb
-        @test v_none.inner.inner_a == Silent()
+        @test v_none.inner.inner_a == Silent
         # None preset should produce a {false} instance — disabled at the type level
         @test typeof(v_none) <: AbstractVerbositySpecifier{false}
 
         v_min = OuterVerb(Minimal())
-        @test v_min.outer_a == WarnLevel()
-        @test v_min.inner.inner_a == WarnLevel()
+        @test v_min.outer_a == WarnLevel
+        @test v_min.inner.inner_a == WarnLevel
         @test typeof(v_min) <: AbstractVerbositySpecifier{true}
 
         v_all = OuterVerb(All())
-        @test v_all.outer_a == DebugLevel()
-        @test v_all.inner.inner_b == DebugLevel()
+        @test v_all.outer_a == DebugLevel
+        @test v_all.inner.inner_b == DebugLevel
     end
 
     @testset "Override sub_specifier field via kwarg with another verbosity instance" begin
         custom_inner = InnerVerb(All())
         v = OuterVerb(inner = custom_inner)
         @test v.inner === custom_inner
-        @test v.outer_a == InfoLevel()  # default from Standard preset
+        @test v.outer_a == InfoLevel  # default from Standard preset
     end
 
     @testset "Override sub_specifier field via kwarg with a preset value" begin
         v = OuterVerb(inner = None())
         @test v.inner isa None
-        @test v.outer_a == InfoLevel()  # from Standard preset
+        @test v.outer_a == InfoLevel  # from Standard preset
     end
 
     @testset "Override toggle field via kwarg" begin
-        v = OuterVerb(outer_a = ErrorLevel())
-        @test v.outer_a == ErrorLevel()
-        @test v.outer_b == WarnLevel()  # from Standard preset
+        v = OuterVerb(outer_a = ErrorLevel)
+        @test v.outer_a == ErrorLevel
+        @test v.outer_b == WarnLevel  # from Standard preset
         @test v.inner isa InnerVerb     # from Standard preset
     end
 
     @testset "Group still applies to toggle fields" begin
-        v = OuterVerb(outer_group = ErrorLevel())
-        @test v.outer_a == ErrorLevel()
-        @test v.outer_b == ErrorLevel()
+        v = OuterVerb(outer_group = ErrorLevel)
+        @test v.outer_a == ErrorLevel
+        @test v.outer_b == ErrorLevel
         @test v.inner isa InnerVerb     # sub_specifier untouched
     end
 
@@ -668,12 +668,12 @@ end
         v = OuterVerb(
             preset = Detailed(),
             inner = InnerVerb(None()),
-            outer_group = WarnLevel(),
-            outer_a = ErrorLevel()
+            outer_group = WarnLevel,
+            outer_a = ErrorLevel
         )
-        @test v.outer_a == ErrorLevel()                # individual wins
-        @test v.outer_b == WarnLevel()                 # from group
-        @test v.inner.inner_a == Silent()              # from explicit InnerVerb(None())
+        @test v.outer_a == ErrorLevel                # individual wins
+        @test v.outer_b == WarnLevel                 # from group
+        @test v.inner.inner_a == Silent              # from explicit InnerVerb(None())
     end
 
     @testset "Validation: toggle field requires MessageLevel" begin
@@ -685,13 +685,13 @@ end
     end
 
     @testset "Validation: sub_specifier field rejects non-spec/non-preset values" begin
-        @test_throws ArgumentError OuterVerb(inner = InfoLevel())
+        @test_throws ArgumentError OuterVerb(inner = InfoLevel)
         @test_throws ArgumentError OuterVerb(inner = "not a spec")
         @test_throws ArgumentError OuterVerb(inner = 42)
     end
 
     @testset "Unknown field still raises" begin
-        @test_throws ArgumentError OuterVerb(not_a_real_field = InfoLevel())
+        @test_throws ArgumentError OuterVerb(not_a_real_field = InfoLevel)
     end
 end
 

--- a/test/generation_test.jl
+++ b/test/generation_test.jl
@@ -542,11 +542,11 @@ end
     toggles = (:inner_a, :inner_b)
 
     presets = (
-        None     = (inner_a = Silent(),    inner_b = Silent()),
-        Minimal  = (inner_a = WarnLevel(), inner_b = Silent()),
+        None = (inner_a = Silent(), inner_b = Silent()),
+        Minimal = (inner_a = WarnLevel(), inner_b = Silent()),
         Standard = (inner_a = InfoLevel(), inner_b = WarnLevel()),
         Detailed = (inner_a = DebugLevel(), inner_b = InfoLevel()),
-        All      = (inner_a = DebugLevel(), inner_b = DebugLevel()),
+        All = (inner_a = DebugLevel(), inner_b = DebugLevel()),
     )
 
     groups = ()
@@ -562,27 +562,27 @@ end
         None = (
             outer_a = Silent(),
             outer_b = Silent(),
-            inner   = InnerVerb(None()),
+            inner = InnerVerb(None()),
         ),
         Minimal = (
             outer_a = WarnLevel(),
             outer_b = Silent(),
-            inner   = InnerVerb(Minimal()),
+            inner = InnerVerb(Minimal()),
         ),
         Standard = (
             outer_a = InfoLevel(),
             outer_b = WarnLevel(),
-            inner   = InnerVerb(Standard()),
+            inner = InnerVerb(Standard()),
         ),
         Detailed = (
             outer_a = DebugLevel(),
             outer_b = InfoLevel(),
-            inner   = InnerVerb(Detailed()),
+            inner = InnerVerb(Detailed()),
         ),
         All = (
             outer_a = DebugLevel(),
             outer_b = DebugLevel(),
-            inner   = InnerVerb(All()),
+            inner = InnerVerb(All()),
         ),
     )
 
@@ -665,10 +665,10 @@ end
 
     @testset "Combined preset + specifier override + group + individual" begin
         v = OuterVerb(
-            preset      = Detailed(),
-            inner       = InnerVerb(None()),
+            preset = Detailed(),
+            inner = InnerVerb(None()),
             outer_group = WarnLevel(),
-            outer_a     = ErrorLevel()
+            outer_a = ErrorLevel()
         )
         @test v.outer_a == ErrorLevel()                # individual wins
         @test v.outer_b == WarnLevel()                 # from group
@@ -698,5 +698,5 @@ end
 # This guards against accidentally regressing the backward-compatible code path.
 @testset "Toggle-only spec retains Union field typing" begin
     @test fieldtype(VerbSpec{true}, :toggle1) ===
-          Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
+        Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
 end

--- a/test/generation_test.jl
+++ b/test/generation_test.jl
@@ -294,7 +294,7 @@ end
             no_right_preconditioning = Silent,
             using_IterativeSolvers = Silent,
             IterativeSolvers_iterations = Silent,
-            KrylovKit_verbosity = CustomLevel(1),
+            KrylovKit_verbosity = MessageLevel(1),
             KrylovJL_verbosity = Silent,
             HYPRE_verbosity = InfoLevel,
             pardiso_verbosity = Silent,
@@ -312,10 +312,10 @@ end
             no_right_preconditioning = InfoLevel,
             using_IterativeSolvers = InfoLevel,
             IterativeSolvers_iterations = Silent,
-            KrylovKit_verbosity = CustomLevel(2),
-            KrylovJL_verbosity = CustomLevel(1),
+            KrylovKit_verbosity = MessageLevel(2),
+            KrylovJL_verbosity = MessageLevel(1),
             HYPRE_verbosity = InfoLevel,
-            pardiso_verbosity = CustomLevel(1),
+            pardiso_verbosity = MessageLevel(1),
             blas_errors = WarnLevel,
             blas_invalid_args = WarnLevel,
             blas_info = InfoLevel,
@@ -330,10 +330,10 @@ end
             no_right_preconditioning = InfoLevel,
             using_IterativeSolvers = InfoLevel,
             IterativeSolvers_iterations = InfoLevel,
-            KrylovKit_verbosity = CustomLevel(3),
-            KrylovJL_verbosity = CustomLevel(1),
+            KrylovKit_verbosity = MessageLevel(3),
+            KrylovJL_verbosity = MessageLevel(1),
             HYPRE_verbosity = InfoLevel,
-            pardiso_verbosity = CustomLevel(1),
+            pardiso_verbosity = MessageLevel(1),
             blas_errors = WarnLevel,
             blas_invalid_args = WarnLevel,
             blas_info = InfoLevel,
@@ -363,7 +363,7 @@ end
         v = LinearVerbosity()
         @test v.blas_errors == WarnLevel
         @test v.default_lu_fallback == Silent
-        @test v.KrylovKit_verbosity == CustomLevel(1)
+        @test v.KrylovKit_verbosity == MessageLevel(1)
     end
 
     @testset "Preset constructors" begin

--- a/test/generation_test.jl
+++ b/test/generation_test.jl
@@ -1,6 +1,6 @@
 using SciMLLogging
 using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage,
-    AbstractVerbosityPreset, MessageLevel, AbstractMessageLevel, WarnLevel, InfoLevel,
+    AbstractVerbosityPreset, MessageLevel, WarnLevel, InfoLevel,
     ErrorLevel, Silent, None, All, Minimal, Standard, Detailed, @verbosity_specifier
 using Logging
 using Test
@@ -383,46 +383,49 @@ end
     end
 end
 
-# Test with preset types as toggle values (useful for verb specs that hold other verb specs, e.g. NonlinearVerbosity)
+# Test with a sub_specifier holding a preset value (useful for verb specs that
+# hold other verb specs, e.g. DEVerbosity holding a NonlinearVerbosity).
 @verbosity_specifier HierarchicalVerbosity begin
-    toggles = (:component_a, :component_b, :component_c)
+    toggles = (:component_a, :component_c)
+
+    sub_specifiers = (:component_b,)
 
     presets = (
         None = (
             component_a = Silent(),
-            component_b = Silent(),
+            component_b = None(),
             component_c = Silent(),
         ),
         Minimal = (
             component_a = WarnLevel(),
-            component_b = Minimal(),  # Reference to another preset
+            component_b = Minimal(),
             component_c = InfoLevel(),
         ),
         Standard = (
             component_a = InfoLevel(),
-            component_b = Standard(),  # Reference to another preset
+            component_b = Standard(),
             component_c = WarnLevel(),
         ),
         Detailed = (
             component_a = DebugLevel(),
-            component_b = Detailed(),  # Reference to another preset
+            component_b = Detailed(),
             component_c = InfoLevel(),
         ),
         All = (
             component_a = ErrorLevel(),
-            component_b = All(),  # Reference to another preset
+            component_b = All(),
             component_c = DebugLevel(),
         ),
     )
 
     groups = (
         main = (:component_a,),
-        auxiliary = (:component_b, :component_c),
+        auxiliary = (:component_c,),
     )
 end
 
 @testset "HierarchicalVerbosity with Preset References" begin
-    @testset "Preset as toggle value" begin
+    @testset "Preset as sub_specifier value" begin
         v = HierarchicalVerbosity(preset = Minimal())
         @test v.component_a == WarnLevel()
         @test v.component_b == Minimal()  # Should be the preset type, not expanded
@@ -434,16 +437,14 @@ end
         @test v2.component_c == WarnLevel()
     end
 
-    @testset "Override preset-typed toggle" begin
-        # Override a preset-typed toggle with a message level
-        v = HierarchicalVerbosity(preset = Standard(), component_b = ErrorLevel())
+    @testset "Override sub_specifier with another preset" begin
+        v = HierarchicalVerbosity(preset = Standard(), component_b = Detailed())
         @test v.component_a == InfoLevel()
-        @test v.component_b == ErrorLevel()  # Overridden
+        @test v.component_b == Detailed()  # Overridden
         @test v.component_c == WarnLevel()
     end
 
-    @testset "Set toggle to preset via kwarg" begin
-        # Set a toggle to a preset type using kwargs
+    @testset "Set sub_specifier to preset via kwarg" begin
         v = HierarchicalVerbosity(component_a = InfoLevel(), component_b = Detailed())
         @test v.component_a == InfoLevel()
         @test v.component_b == Detailed()  # Set to preset type via kwarg
@@ -552,11 +553,11 @@ end
     groups = ()
 end
 
-# Outer spec exercising the `specifiers` block: holds toggles AND a sub-specifier field
+# Outer spec exercising the `sub_specifiers` block: holds toggles AND a sub-specifier field
 @verbosity_specifier OuterVerb begin
     toggles = (:outer_a, :outer_b)
 
-    specifiers = (:inner,)
+    sub_specifiers = (:inner,)
 
     presets = (
         None = (
@@ -591,19 +592,19 @@ end
     )
 end
 
-@testset "OuterVerb with specifiers block" begin
+@testset "OuterVerb with sub_specifiers block" begin
     @testset "Field typing" begin
         v = OuterVerb()
         T = typeof(v)
-        # Toggle fields must be concretely typed as MessageLevel when specifiers block is present
+        # Toggle fields are always concretely typed as MessageLevel
         @test fieldtype(T, :outer_a) === MessageLevel
         @test fieldtype(T, :outer_b) === MessageLevel
-        # Specifier fields are parametric and resolve to the concrete instance type —
-        # this is what lets `outer.inner.toggle` flow through inference without
-        # collapsing into an abstract Union.
+        # Sub-specifier fields are parametric and resolve to the concrete instance
+        # type — this is what lets `outer.inner.toggle` flow through inference
+        # without collapsing into an abstract Union.
         @test fieldtype(T, :inner) === InnerVerb{true}
         @test isconcretetype(fieldtype(T, :inner))
-        # The outer struct has an extra type parameter for the specifier slot
+        # The outer struct has an extra type parameter for the sub_specifier slot
         @test T <: OuterVerb{true}
         @test T !== OuterVerb{true}
     end
@@ -617,7 +618,7 @@ end
         @test v.inner.inner_b == WarnLevel()
     end
 
-    @testset "Preset constructors set both toggles and specifiers" begin
+    @testset "Preset constructors set both toggles and sub_specifiers" begin
         v_none = OuterVerb(None())
         @test v_none.outer_a == Silent()
         @test v_none.outer_b == Silent()
@@ -636,14 +637,14 @@ end
         @test v_all.inner.inner_b == DebugLevel()
     end
 
-    @testset "Override specifier field via kwarg with another verbosity instance" begin
+    @testset "Override sub_specifier field via kwarg with another verbosity instance" begin
         custom_inner = InnerVerb(All())
         v = OuterVerb(inner = custom_inner)
         @test v.inner === custom_inner
         @test v.outer_a == InfoLevel()  # default from Standard preset
     end
 
-    @testset "Override specifier field via kwarg with a preset value" begin
+    @testset "Override sub_specifier field via kwarg with a preset value" begin
         v = OuterVerb(inner = None())
         @test v.inner isa None
         @test v.outer_a == InfoLevel()  # from Standard preset
@@ -660,10 +661,10 @@ end
         v = OuterVerb(outer_group = ErrorLevel())
         @test v.outer_a == ErrorLevel()
         @test v.outer_b == ErrorLevel()
-        @test v.inner isa InnerVerb     # specifier untouched
+        @test v.inner isa InnerVerb     # sub_specifier untouched
     end
 
-    @testset "Combined preset + specifier override + group + individual" begin
+    @testset "Combined preset + sub_specifier override + group + individual" begin
         v = OuterVerb(
             preset = Detailed(),
             inner = InnerVerb(None()),
@@ -675,15 +676,15 @@ end
         @test v.inner.inner_a == Silent()              # from explicit InnerVerb(None())
     end
 
-    @testset "Validation: toggle field requires MessageLevel when specifiers block is declared" begin
-        # When specifiers block is present, toggles must be a MessageLevel — passing a preset
-        # or another verbosity specifier as a toggle is rejected.
+    @testset "Validation: toggle field requires MessageLevel" begin
+        # Toggles must be a MessageLevel — passing a preset or another verbosity
+        # specifier as a toggle is rejected.
         @test_throws ArgumentError OuterVerb(outer_a = None())
         @test_throws ArgumentError OuterVerb(outer_a = InnerVerb())
         @test_throws ArgumentError OuterVerb(outer_a = "not a level")
     end
 
-    @testset "Validation: specifier field rejects non-spec/non-preset values" begin
+    @testset "Validation: sub_specifier field rejects non-spec/non-preset values" begin
         @test_throws ArgumentError OuterVerb(inner = InfoLevel())
         @test_throws ArgumentError OuterVerb(inner = "not a spec")
         @test_throws ArgumentError OuterVerb(inner = 42)
@@ -694,9 +695,9 @@ end
     end
 end
 
-# Sanity check: a spec without a specifiers block keeps the wider toggle Union typing.
-# This guards against accidentally regressing the backward-compatible code path.
-@testset "Toggle-only spec retains Union field typing" begin
-    @test fieldtype(VerbSpec{true}, :toggle1) ===
-        Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
+# All toggle fields are concretely typed `::MessageLevel`, regardless of whether
+# a `sub_specifiers` block is declared.
+@testset "Toggle fields always typed MessageLevel" begin
+    @test fieldtype(VerbSpec{true}, :toggle1) === MessageLevel
+    @test fieldtype(LinearVerbosity{true}, :blas_errors) === MessageLevel
 end

--- a/test/generation_test.jl
+++ b/test/generation_test.jl
@@ -1,7 +1,7 @@
 using SciMLLogging
 using SciMLLogging: SciMLLogging, AbstractVerbositySpecifier, @SciMLMessage,
-    AbstractVerbosityPreset, AbstractMessageLevel, WarnLevel, InfoLevel,
-    ErrorLevel, Silent, None, All, Minimal, @verbosity_specifier
+    AbstractVerbosityPreset, MessageLevel, AbstractMessageLevel, WarnLevel, InfoLevel,
+    ErrorLevel, Silent, None, All, Minimal, Standard, Detailed, @verbosity_specifier
 using Logging
 using Test
 
@@ -535,4 +535,168 @@ end
         @test v.preconditioner == Silent()  # From preset
         @test v.convergence == ErrorLevel()  # From preset
     end
+end
+
+# Inner spec used as a sub-specifier below
+@verbosity_specifier InnerVerb begin
+    toggles = (:inner_a, :inner_b)
+
+    presets = (
+        None     = (inner_a = Silent(),    inner_b = Silent()),
+        Minimal  = (inner_a = WarnLevel(), inner_b = Silent()),
+        Standard = (inner_a = InfoLevel(), inner_b = WarnLevel()),
+        Detailed = (inner_a = DebugLevel(), inner_b = InfoLevel()),
+        All      = (inner_a = DebugLevel(), inner_b = DebugLevel()),
+    )
+
+    groups = ()
+end
+
+# Outer spec exercising the `specifiers` block: holds toggles AND a sub-specifier field
+@verbosity_specifier OuterVerb begin
+    toggles = (:outer_a, :outer_b)
+
+    specifiers = (:inner,)
+
+    presets = (
+        None = (
+            outer_a = Silent(),
+            outer_b = Silent(),
+            inner   = InnerVerb(None()),
+        ),
+        Minimal = (
+            outer_a = WarnLevel(),
+            outer_b = Silent(),
+            inner   = InnerVerb(Minimal()),
+        ),
+        Standard = (
+            outer_a = InfoLevel(),
+            outer_b = WarnLevel(),
+            inner   = InnerVerb(Standard()),
+        ),
+        Detailed = (
+            outer_a = DebugLevel(),
+            outer_b = InfoLevel(),
+            inner   = InnerVerb(Detailed()),
+        ),
+        All = (
+            outer_a = DebugLevel(),
+            outer_b = DebugLevel(),
+            inner   = InnerVerb(All()),
+        ),
+    )
+
+    groups = (
+        outer_group = (:outer_a, :outer_b),
+    )
+end
+
+@testset "OuterVerb with specifiers block" begin
+    @testset "Field typing" begin
+        v = OuterVerb()
+        T = typeof(v)
+        # Toggle fields must be concretely typed as MessageLevel when specifiers block is present
+        @test fieldtype(T, :outer_a) === MessageLevel
+        @test fieldtype(T, :outer_b) === MessageLevel
+        # Specifier fields are parametric and resolve to the concrete instance type —
+        # this is what lets `outer.inner.toggle` flow through inference without
+        # collapsing into an abstract Union.
+        @test fieldtype(T, :inner) === InnerVerb{true}
+        @test isconcretetype(fieldtype(T, :inner))
+        # The outer struct has an extra type parameter for the specifier slot
+        @test T <: OuterVerb{true}
+        @test T !== OuterVerb{true}
+    end
+
+    @testset "Default constructor" begin
+        v = OuterVerb()
+        @test v.outer_a == InfoLevel()
+        @test v.outer_b == WarnLevel()
+        @test v.inner isa InnerVerb
+        @test v.inner.inner_a == InfoLevel()
+        @test v.inner.inner_b == WarnLevel()
+    end
+
+    @testset "Preset constructors set both toggles and specifiers" begin
+        v_none = OuterVerb(None())
+        @test v_none.outer_a == Silent()
+        @test v_none.outer_b == Silent()
+        @test v_none.inner isa InnerVerb
+        @test v_none.inner.inner_a == Silent()
+        # None preset should produce a {false} instance — disabled at the type level
+        @test typeof(v_none) <: AbstractVerbositySpecifier{false}
+
+        v_min = OuterVerb(Minimal())
+        @test v_min.outer_a == WarnLevel()
+        @test v_min.inner.inner_a == WarnLevel()
+        @test typeof(v_min) <: AbstractVerbositySpecifier{true}
+
+        v_all = OuterVerb(All())
+        @test v_all.outer_a == DebugLevel()
+        @test v_all.inner.inner_b == DebugLevel()
+    end
+
+    @testset "Override specifier field via kwarg with another verbosity instance" begin
+        custom_inner = InnerVerb(All())
+        v = OuterVerb(inner = custom_inner)
+        @test v.inner === custom_inner
+        @test v.outer_a == InfoLevel()  # default from Standard preset
+    end
+
+    @testset "Override specifier field via kwarg with a preset value" begin
+        v = OuterVerb(inner = None())
+        @test v.inner isa None
+        @test v.outer_a == InfoLevel()  # from Standard preset
+    end
+
+    @testset "Override toggle field via kwarg" begin
+        v = OuterVerb(outer_a = ErrorLevel())
+        @test v.outer_a == ErrorLevel()
+        @test v.outer_b == WarnLevel()  # from Standard preset
+        @test v.inner isa InnerVerb     # from Standard preset
+    end
+
+    @testset "Group still applies to toggle fields" begin
+        v = OuterVerb(outer_group = ErrorLevel())
+        @test v.outer_a == ErrorLevel()
+        @test v.outer_b == ErrorLevel()
+        @test v.inner isa InnerVerb     # specifier untouched
+    end
+
+    @testset "Combined preset + specifier override + group + individual" begin
+        v = OuterVerb(
+            preset      = Detailed(),
+            inner       = InnerVerb(None()),
+            outer_group = WarnLevel(),
+            outer_a     = ErrorLevel()
+        )
+        @test v.outer_a == ErrorLevel()                # individual wins
+        @test v.outer_b == WarnLevel()                 # from group
+        @test v.inner.inner_a == Silent()              # from explicit InnerVerb(None())
+    end
+
+    @testset "Validation: toggle field requires MessageLevel when specifiers block is declared" begin
+        # When specifiers block is present, toggles must be a MessageLevel — passing a preset
+        # or another verbosity specifier as a toggle is rejected.
+        @test_throws ArgumentError OuterVerb(outer_a = None())
+        @test_throws ArgumentError OuterVerb(outer_a = InnerVerb())
+        @test_throws ArgumentError OuterVerb(outer_a = "not a level")
+    end
+
+    @testset "Validation: specifier field rejects non-spec/non-preset values" begin
+        @test_throws ArgumentError OuterVerb(inner = InfoLevel())
+        @test_throws ArgumentError OuterVerb(inner = "not a spec")
+        @test_throws ArgumentError OuterVerb(inner = 42)
+    end
+
+    @testset "Unknown field still raises" begin
+        @test_throws ArgumentError OuterVerb(not_a_real_field = InfoLevel())
+    end
+end
+
+# Sanity check: a spec without a specifiers block keeps the wider toggle Union typing.
+# This guards against accidentally regressing the backward-compatible code path.
+@testset "Toggle-only spec retains Union field typing" begin
+    @test fieldtype(VerbSpec{true}, :toggle1) ===
+          Union{MessageLevel, AbstractVerbosityPreset, AbstractVerbositySpecifier}
 end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -10,14 +10,14 @@ using Test
 
     presets = (
         None = (
-            a = Silent(),
-            b = Silent(),
-            c = Silent(),
+            a = Silent,
+            b = Silent,
+            c = Silent,
         ),
         Standard = (
-            a = WarnLevel(),
-            b = InfoLevel(),
-            c = ErrorLevel(),
+            a = WarnLevel,
+            b = InfoLevel,
+            c = ErrorLevel,
         ),
     )
 

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -27,7 +27,7 @@ end
 function emit_all(verbose)
     @SciMLMessage("msg a", verbose, :a)
     @SciMLMessage("msg b", verbose, :b)
-    @SciMLMessage("msg c", verbose, :c)
+    @SciMLMessage(lazy"msg c", verbose, :c)
     return nothing
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ if GROUP == "Core" || GROUP == "All"
     @time @safetestset "Explicit Imports" include("explicit_imports.jl")
 end
 
-if GROUP == "NoPre" && isempty(VERSION.prerelease)
+if (GROUP == "NoPre" || GROUP == "All") && isempty(VERSION.prerelease)
     activate_env("nopre")
     @time @safetestset "JET" include("nopre/jet.jl")
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Motivated by the fact that currently, simply changing any logging level is enough to trigger recompilation.

Currently, every toggle in a verbosity specifier has it's own type parameter associated to it, meaning that logging can be on at certain logging sites, and for others the logging / field getting and bool comparison code will be completely eliminated. However, that means that every time a log level is changed, all of the code that uses the verbosity specifier needs to be recompiled.

This makes it so that there's just one type parameter that determines whether logging is turned on or off. This means that if there are any logging sites that emit a message, even logging sites that are disabled will incur the cost of a field access and a Bool comparison, when checking if anything should be sent to the logging backend. 

Benchmarking and profiling indicate that the cost of the field access and Bool comparison is entirely insignificant, even in hot loops. 

I'll be posting profiling and benchmark results here, along with checks making sure that the code is still trimmable. 
