### PR TITLE
Qualify types access in macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLLogging"
 uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 authors = ["Jadon Clugston"]
-version = "1.10.0"
+version = "1.10.1"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -133,14 +133,14 @@ macro verbosity_specifier(name, block)
     custom_presets = filter(p -> !(p in standard_presets), preset_names)
 
     # Generate custom preset types
-    custom_preset_defs = [:(struct $p <: AbstractVerbosityPreset end) for p in custom_presets]
+    custom_preset_defs = [:(struct $p <: SciMLLogging.AbstractVerbosityPreset end) for p in custom_presets]
 
     # Generate parametric struct
     type_params = [Symbol("T$i") for i in eachindex(toggles)]
     struct_fields = [:($(toggles[i])::$(type_params[i])) for i in eachindex(toggles)]
 
     struct_def = :(
-        struct $name{$(type_params...)} <: AbstractVerbositySpecifier
+        struct $name{$(type_params...)} <: SciMLLogging.AbstractVerbositySpecifier
             $(struct_fields...)
         end
     )
@@ -185,7 +185,7 @@ macro verbosity_specifier(name, block)
         )
         push!(
             group_validations, quote
-                if $(group_name) !== nothing && !($(group_name) isa AbstractMessageLevel)
+                if $(group_name) !== nothing && !($(group_name) isa SciMLLogging.AbstractMessageLevel)
                     throw(ArgumentError($lazy_str))
                 end
             end
@@ -251,7 +251,7 @@ macro verbosity_specifier(name, block)
             $(group_validations...)
 
             # Validate preset
-            if preset !== nothing && !(preset isa AbstractVerbosityPreset)
+            if preset !== nothing && !(preset isa SciMLLogging.AbstractVerbosityPreset)
                 throw(ArgumentError($preset_error_str))
             end
 
@@ -260,13 +260,13 @@ macro verbosity_specifier(name, block)
                 if !(key in $(Tuple(toggles)))
                     throw(ArgumentError($unknown_option_str))
                 end
-                if !(value isa AbstractMessageLevel || value isa AbstractVerbosityPreset || value isa AbstractVerbositySpecifier)
+                if !(value isa SciMLLogging.AbstractMessageLevel || value isa SciMLLogging.AbstractVerbosityPreset || value isa SciMLLogging.AbstractVerbositySpecifier)
                     throw(ArgumentError($invalid_type_str))
                 end
             end
 
             # Get preset config
-            preset_to_use = preset === nothing ? Standard() : preset
+            preset_to_use = preset === nothing ? SciMLLogging.Standard() : preset
             preset_config = $(Symbol("_preset_map_", name))[typeof(preset_to_use).name.name]
 
             # Apply precedence

--- a/src/verbspec_generation_macro.jl
+++ b/src/verbspec_generation_macro.jl
@@ -133,14 +133,14 @@ macro verbosity_specifier(name, block)
     custom_presets = filter(p -> !(p in standard_presets), preset_names)
 
     # Generate custom preset types
-    custom_preset_defs = [:(struct $p <: SciMLLogging.AbstractVerbosityPreset end) for p in custom_presets]
+    custom_preset_defs = [:(struct $p <: $(AbstractVerbosityPreset) end) for p in custom_presets]
 
     # Generate parametric struct
     type_params = [Symbol("T$i") for i in eachindex(toggles)]
     struct_fields = [:($(toggles[i])::$(type_params[i])) for i in eachindex(toggles)]
 
     struct_def = :(
-        struct $name{$(type_params...)} <: SciMLLogging.AbstractVerbositySpecifier
+        struct $name{$(type_params...)} <: $(AbstractVerbositySpecifier)
             $(struct_fields...)
         end
     )
@@ -185,7 +185,7 @@ macro verbosity_specifier(name, block)
         )
         push!(
             group_validations, quote
-                if $(group_name) !== nothing && !($(group_name) isa SciMLLogging.AbstractMessageLevel)
+                if $(group_name) !== nothing && !($(group_name) isa $(AbstractMessageLevel))
                     throw(ArgumentError($lazy_str))
                 end
             end
@@ -251,7 +251,7 @@ macro verbosity_specifier(name, block)
             $(group_validations...)
 
             # Validate preset
-            if preset !== nothing && !(preset isa SciMLLogging.AbstractVerbosityPreset)
+            if preset !== nothing && !(preset isa $(AbstractVerbosityPreset))
                 throw(ArgumentError($preset_error_str))
             end
 
@@ -260,13 +260,13 @@ macro verbosity_specifier(name, block)
                 if !(key in $(Tuple(toggles)))
                     throw(ArgumentError($unknown_option_str))
                 end
-                if !(value isa SciMLLogging.AbstractMessageLevel || value isa SciMLLogging.AbstractVerbosityPreset || value isa SciMLLogging.AbstractVerbositySpecifier)
+                if !(value isa $(AbstractMessageLevel) || value isa $(AbstractVerbosityPreset) || value isa $(AbstractVerbositySpecifier))
                     throw(ArgumentError($invalid_type_str))
                 end
             end
 
             # Get preset config
-            preset_to_use = preset === nothing ? SciMLLogging.Standard() : preset
+            preset_to_use = preset === nothing ? $(Standard)() : preset
             preset_config = $(Symbol("_preset_map_", name))[typeof(preset_to_use).name.name]
 
             # Apply precedence


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
This just makes it so that the macro calls some appropriate symbols internally, instead of needing them to be imported. This is really what should have been done all along, and I'll make a similar change to main, but this is needed to help with some of the forward compatibility stuff. 