### PR TITLE
ci: migrate Tests and Documentation to centralized workflows (pilot)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,15 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.group }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    env:
-      GROUP: ${{ matrix.group }}
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      actions: write
-      contents: read
+  tests:
+    name: "Tests"
     strategy:
       fail-fast: true
       matrix:
@@ -28,31 +21,18 @@ jobs:
           - '1'
           - 'lts'
           - 'pre'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
         group:
           - Core
         include:
           - version: '1'
-            os: ubuntu-latest
-            arch: x64
             group: NoPre
           - version: 'lts'
-            os: ubuntu-latest
-            arch: x64
             group: NoPre
           - version: '1'
-            os: ubuntu-latest
-            arch: x64
             group: Downstream
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+      coverage: false
+    secrets: "inherit"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,5 +1,4 @@
 name: Documentation
-
 on:
   push:
     branches:
@@ -8,26 +7,15 @@ on:
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]
-
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs/ docs/make.jl
+  docs:
+    name: "Documentation"
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      coverage: false
+    secrets: "inherit"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft. This is the **pilot** for the centralized-workflow migration of the ~45 single-package SciML repos still on bespoke CI — review the pattern here before I batch the rest.

### What changes
| Workflow | Action |
|---|---|
| `CI.yml` | → thin caller of `SciML/.github/.github/workflows/tests.yml@v1` |
| `Documentation.yml` | → thin caller of `documentation.yml@v1` |
| `FormatCheck.yml` | **unchanged** (stays on Runic) |
| `Downstream.yml` | **unchanged** for now (see below) |
| `TagBot.yml`, `CompatHelper.yml` | unchanged |

### Behavior preserved
- **CI**: the 6-job matrix is reproduced exactly — Core on `1`/`lts`/`pre`, NoPre on `1`/`lts`, Downstream on `1`. `coverage: false` keeps this job's prior no-coverage behavior.
- **Docs**: `coverage: false` matches the prior docs build (no coverage). `DOCUMENTER_KEY`/`GITHUB_TOKEN` flow via `secrets: inherit`.
- Minor deltas, consistent with all current adopters: per-job `timeout-minutes: 60` dropped (no input on the reusable workflow), and `arch` comes from `runner.arch` (X64) instead of hardcoded `x64`.

### Deliberately deferred (findings from the pilot)
1. **FormatCheck stays on Runic.** The centralized `format-check.yml` runs JuliaFormatter+SciMLStyle and is not a drop-in for Runic repos. DataInterpolations.jl (an adopter) keeps its Runic check locally for the same reason. → *A Runic option on the centralized format workflow would let these migrate too.*
2. **Downstream stays bespoke.** The centralized `downstream.yml` hardcodes codecov `fail_ci_if_error: true`, but this repo deliberately uses `false`. Migrating as-is would silently flip it. → *Needs a `fail-ci-if-error` input on the reusable workflow first.*

### ⚠️ Merge prerequisite
The job/check names change (e.g. `test (...)` → `Tests / Tests - Core`). **Branch-protection required-status-checks must be updated** to the new names, or merges will be blocked. This applies to every repo in the campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)