### PR TITLE
Add Spell Check (typos) CI to SciMLLogging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,14 @@
+name: "Spell Check"
+
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+
+jobs:
+  typos-check:
+    name: "Spell Check"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/docs/src/manual/presets.md
+++ b/docs/src/manual/presets.md
@@ -10,7 +10,7 @@ The general idea behind the preset levels is as follows. Each lower level keeps 
 
 * `None` makes it easy to turn off all printing/logging to ensure 0 overhead and 0 noise.
 * `Minimal` turns on only the fatal errors, for example solvers exiting early due to instability, which the user must react to in order to appropriately compute correctly.
-* `Standard` turns on non-fatal but critical warnings, for example major performance warnings or deprecations which have been flagged that the user almost certaintly should
+* `Standard` turns on non-fatal but critical warnings, for example major performance warnings or deprecations which have been flagged that the user almost certainly should
   respond to. While the program is still running correctly if these are firing, this is the level on by default to signal to the wider userbase issues which should be
   handled in order to have "normal" running code.
 * `Detailed` turns on additional information as part of the run which can be helpful for in-depth debugging. This includes information about critical quantities at each step
@@ -26,10 +26,10 @@ The general idea behind the preset levels is as follows. Each lower level keeps 
 * In the ODE solver, if `dt<dtmin` the solver needs to exit. Almost all users should be notified of this behavior in order to understand why the solver did not go to the final time.
   This should be set as a `WarnLevel` in the `Minimal` preset.
 * In LinearSolve.jl's default methods, it has the ability to swap from using an LU factorization to a column-pivoted QR factorization behind the scenes if a singular matrix is detected.
-  Since LinearSolve.jl automatically recovers from any error here, most users do not need to know if this has happened, thus it is a solver behavoir that should be logged at the `Detailed`
+  Since LinearSolve.jl automatically recovers from any error here, most users do not need to know if this has happened, thus it is a solver behavior that should be logged at the `Detailed`
   level because it's non-verbose and no extra cost to know, but can be a critical debugging information.
 * In SciMLSensitivity.jl's default vjp method, it has to run through a bunch of different potential reverse-mode AD methods to see which is compatible with the user's `f`. If none of the
-  AD methods are compatible, it needs to fallback to `FiniteDiffVJP`, which is finite differencing and thus changes the `J'v` calcuation from O(n) matrix-free to O(n^2) building J. This is
+  AD methods are compatible, it needs to fallback to `FiniteDiffVJP`, which is finite differencing and thus changes the `J'v` calculation from O(n) matrix-free to O(n^2) building J. This is
   a massive difference in computational cost which most users should know about, as it should generally be considered incorrect behavior to require finite differencing here and the user
   should be notified by default about this fallback. Thus it should be given `WarnLevel` in the `Standard` preset, since it's not critical so it's not `Minimal`. In the `Detailed` preset,
   the vjp choice should additionally be shared every time even if it's not finite differencing.
@@ -37,7 +37,7 @@ The general idea behind the preset levels is as follows. Each lower level keeps 
   methods aren't converging well, or whether ODE solves should have difficulties handling a given step. However, `cond(A)` is a very expensive calculation, sometimes more expensive than the
   solver itself, and thus it should only be enabled when maximum information is needed. Thus this printing would only be enabled when `All` is chosen.
 * The default ODE solver has the ability to automatically swap between solvers based on certain qualities of the ODE that are detected, essentially estimating condition number. While
-  this behavior is not necessary for most users to know, it can help a lot while debugging to know exactly when the swaps occured. Since they don't occur often, this information should
+  this behavior is not necessary for most users to know, it can help a lot while debugging to know exactly when the swaps occurred. Since they don't occur often, this information should
   be included in the `Detailed` output, along with some information about why the trigger occurred.
 * Error estimate values of adaptive ODE solvers, eigenvalue estimates in stabilized RK (RKC) methods, and other per-step estimators can be really useful for debugging ODE solvers in order
   to know what specific term  is likely making the solver drop the `dt` to be smaller, but it's very noisy to print tons of information at every step. Thus this information can be setup

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -110,7 +110,7 @@ end
 
 
 """
-    `@SciMLMessage(message, verbosity::AbstracVerbositySpecifier, option::Symbol)`
+    `@SciMLMessage(message, verbosity::AbstractVerbositySpecifier, option::Symbol)`
     `@SciMLMessage(message, verbosity::Bool)`
 
 A macro that emits a log message based on the log level specified in the `option` of the `AbstractVerbositySpecifier` supplied.


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

SciMLLogging had **no typos CI**, which is a gap under the "typos everywhere" standard. This:

- **Adds `SpellCheck.yml`** calling the centralized `spellcheck.yml@v1` (crate-ci/typos).
- **Fixes the real typos** it surfaces so the check is green: `certaintly`, `behavoir`, `calcuation`, `occured` (docs) and `AbstracVerbositySpecifier`→`AbstractVerbositySpecifier` (a `src/utils.jl` docstring).
- **Drops the `crate-ci/typos` ignore** from `dependabot.yml` (keep all actions current; with the centralized SpellCheck workflow, crate-ci/typos isn't referenced in this repo's own workflows anyway).

This is the template for closing the typos gap on the other repos that lack it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)