### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,15 +7,10 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1']
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: LinearSolve.jl, group: All}
           - {user: SciML, repo: NonlinearSolve.jl, group: Core}
@@ -25,40 +20,10 @@ jobs:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Integrators}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression}
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream --depwarn=yes {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+      julia-version: "1"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -11,12 +10,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Centralize CI through SciML/.github reusable workflows (@v1)

This PR routes the remaining bespoke CI workflows through the shared reusable workflows in `SciML/.github`, preserving all existing config (downstream package/group matrix, Julia version, OS, triggers).

### Converted

| Workflow | Before | After |
| --- | --- | --- |
| `Downstream.yml` (IntegrationTest) | inline `Pkg.develop`/`Pkg.update`/`Pkg.test` job with `ResolverError` catch + codecov | `SciML/.github/.github/workflows/downstream.yml@v1` |
| `FormatCheck.yml` | inline `fredrikekre/runic-action@v1` job | `SciML/.github/.github/workflows/runic.yml@v1` |

For `Downstream.yml`, the full downstream package/group matrix (LinearSolve.jl/All, NonlinearSolve.jl/Core, DiffEqBase.jl Core+Downstream+Downstream2, OrdinaryDiffEq.jl Interface+Integrators+Regression), `julia-version: "1"`, ubuntu-latest/x64, and the push/PR/tag triggers are all preserved. The reusable workflow implements the identical `Pkg.develop` + `ResolverError`-catch + coverage/codecov logic that was inlined here, so no behavior is dropped.

For `FormatCheck.yml`, the Runic check (version 1) and its push (master/main/release-) + tag + PR triggers are preserved.

### Already reusable (untouched)

- `CI.yml` — already uses `tests.yml@v1`
- `Documentation.yml` — already uses `documentation.yml@v1`
- `SpellCheck.yml` — already uses `spellcheck.yml@v1`

### Intentionally left local

- `TagBot.yml` — non-CI release automation; no reusable equivalent and out of scope.

### NOTE on branch protection

The required-status-check job names change when routing through the reusable workflows (e.g. the downstream job is now reported as `Downstream Tests - <group>` and the format job as `Runic Format Check`, rather than the old inline job names). **Branch protection required-status-check rules will need updating** to match the new job names after merge.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
