### PR TITLE
Add Downgrade CI

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,23 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  downgrade:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['1.10']
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SciMLLoggingTracyExt = "Tracy"
 
 [compat]
 DocStringExtensions = "0.9.5"
-ExplicitImports = "1.10.3"
+ExplicitImports = "1.10.2"
 Logging = "1.1.0"
 LoggingExtras = "1.1.0"
 Preferences = "1.5.0"


### PR DESCRIPTION
Adds a Downgrade CI workflow (`.github/workflows/Downgrade.yml`) calling `SciML/.github/.github/workflows/downgrade.yml@v1` on Julia 1.10. The repo previously had no downgrade workflow.

## Floor bumps
- **ExplicitImports**: `1.10.3` → `1.10.2`

The declared floor `1.10.3` is a phantom version that was never registered in the General registry (versions go `1.10.2` → `1.11.0`), so the downgrade environment could not resolve. `1.10.2` is the lowest existing version near the declared intent; it resolves and passes the suite.

## Local downgrade suite: PASS
Ran `Pkg.test()` (GROUP=Core) on Julia 1.10 with all non-stdlib deps pinned to their compat floors:
- Basic Tests: 33/33
- Verbosity Specifier Generation Tests: 134/134
- Explicit Imports: 2/2

No tests were loosened, skipped, or modified.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)