### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,9 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.10']
+        version: ['lts']
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,31 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
-    inputs:
-      lookback:
-        default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,143 @@
+[default.extend-words]
+# Julia-specific functions
+indexin = "indexin"
+findfirst = "findfirst"
+findlast = "findlast"
+eachindex = "eachindex"
+setp = "setp"
+getp = "getp"
+setu = "setu"
+getu = "getu"
+
+# Mathematical/scientific terms
+jacobian = "jacobian"
+hessian = "hessian" 
+eigenvalue = "eigenvalue"
+eigenvector = "eigenvector"
+discretization = "discretization"
+linearization = "linearization"
+parameterized = "parameterized"
+discretized = "discretized"
+vectorized = "vectorized"
+extrapolant = "extrapolant"
+# Person names in citations - these are correct spellings
+Sigal = "Sigal"  # Sigal Gottlieb is a real person/author
+Steinebach = "Steinebach"
+Protopapa = "Protopapa"
+Hairer = "Hairer"
+Wanner = "Wanner"
+Verwer = "Verwer"
+Sandu = "Sandu"
+Carmichael = "Carmichael"
+Potra = "Potra"
+Seinfeld = "Seinfeld"
+Dabdub = "Dabdub"
+Marzo = "Marzo"
+Loon = "Loon"
+RODASP = "RODASP"
+Rodas4P = "Rodas4P"
+Rodas5P = "Rodas5P"
+Rodas6P = "Rodas6P"
+Scholz = "Scholz"
+Veldhuizen = "Veldhuizen"
+Tsit5DA = "Tsit5DA"
+Kaps = "Kaps"
+Rentrop = "Rentrop"
+Rang = "Rang"
+Darmstadt = "Darmstadt"
+"Méthodes" = "Méthodes"
+"différentiels" = "différentiels"
+"algébriques" = "algébriques"
+"problèmes" = "problèmes"
+problemes = "problemes"  # French word in citation without accent
+Ono = "Ono"  # Hiroshi Ono, author of Ono10/Ono12 RK methods
+padd = "padd"  # variable name in analyticless_convergence_tests.jl
+Preprint = "Preprint"
+Nr = "Nr"
+Wouver = "Wouver"
+Sauces = "Sauces"
+Schiesser = "Schiesser"
+Vande = "Vande"
+BIT = "BIT"
+Numer = "Numer"
+Jcon = "Jcon"
+arXiv = "arXiv"
+
+# (Numer already declared above for "BIT Numer" context.)
+
+# Technical variable names
+dorder = "dorder"  # Parameter for delta order / order change
+
+
+# Common variable patterns in Julia/SciML
+ists = "ists"
+ispcs = "ispcs"
+osys = "osys"
+rsys = "rsys"
+usys = "usys"
+fsys = "fsys"
+eqs = "eqs"
+rhs = "rhs"
+lhs = "lhs"
+ode = "ode"
+pde = "pde"
+sde = "sde"
+dde = "dde"
+bvp = "bvp"
+ivp = "ivp"
+
+# Common abbreviations
+tol = "tol"
+rtol = "rtol"
+atol = "atol"
+idx = "idx"
+jdx = "jdx"
+prev = "prev"
+curr = "curr"
+init = "init"
+tmp = "tmp"
+vec = "vec"
+arr = "arr"
+dt = "dt"
+du = "du"
+dx = "dx"
+dy = "dy"
+dz = "dz"
+
+# Algorithm/type suffixes
+alg = "alg"
+prob = "prob"
+sol = "sol"
+cb = "cb"
+opts = "opts"
+args = "args"
+kwargs = "kwargs"
+
+# Scientific abbreviations
+ND = "ND"
+nd = "nd"
+MTK = "MTK"
+ODE = "ODE"
+PDE = "PDE"
+SDE = "SDE"
+
+# SDE-specific terms
+IIF = "IIF"  # Integrating Factor method (IIF1M, IIF2M, IIF1Mil)
+iif = "iif"
+currate = "currate"  # current rate variable in tau-leaping
+SIE = "SIE"  # SIEA/SIEB algorithm name prefix
+SME = "SME"  # SME algorithm name (Stochastic Modified Euler)
+resetted = "resetted"  # variable name in stepsize control
+strat = "strat"  # Stratonovich abbreviation
+
+# Variable names used in codebase
+yhat = "yhat"  # estimated y value
+accpt = "accpt"  # accepted step flag variable
+gam = "gam"  # gamma abbreviation in tableaux
+clos = "clos"  # closure abbreviation
+
+# Journal abbreviations in BibTeX citations
+Comput = "Comput"  # J. Comput. Phys. (Journal of Computational Physics)
+
+# Julia spelling convention
+inferrable = "inferrable"  # Julia uses "inferrable" not "inferable"


### PR DESCRIPTION
## Canonical CI cleanup

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot@v1` workflow (with explicit permissions + lookback input) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1`. Not a monorepo (no `lib/`), so single-package form only.
- **Downgrade**: removed the `skip: "Pkg,TOML"` input entirely (both stdlibs, now auto-populated). Changed the downgrade matrix `version: ['1.10']` to `['lts']` (the only source of `julia-version`).
- **Typos starter**: SpellCheck caller exists but no `.typos.toml` at root, so added one (copied from SciML/OrdinaryDiffEq.jl).

Ignore until reviewed by @ChrisRackauckas.
