### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,22 +16,20 @@ SciMLLoggingTracyExt = "Tracy"
 
 [compat]
 DocStringExtensions = "0.9.5"
-ExplicitImports = "1.10.2"
 Logging = "1.1.0"
 LoggingExtras = "1.1.0"
 Preferences = "1.5.0"
 SafeTestsets = "0.1.0, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 Tracy = "0.1"
 julia = "1.10"
 
 [extras]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SafeTestsets", "SciMLTesting", "DocStringExtensions", "ExplicitImports"]
+test = ["Test", "SafeTestsets", "SciMLTesting", "DocStringExtensions"]

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,8 +1,0 @@
-using ExplicitImports
-using SciMLLogging
-using Test
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(SciMLLogging) === nothing
-    @test check_no_stale_explicit_imports(SciMLLogging) === nothing
-end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,6 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -9,8 +9,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SciMLLogging = {path = "../.."}
 
 [compat]
+Aqua = "0.8"
 JET = "0.9, 0.11"
-SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,10 +1,27 @@
-using SciMLLogging
+using SciMLTesting, SciMLLogging, Test
 using SciMLLogging: @SciMLMessage, @verbosity_specifier,
     Silent, InfoLevel, WarnLevel, ErrorLevel,
     None, Standard
 using JET
-using Test
 
+run_qa(
+    SciMLLogging; explicit_imports = true,
+    ei_kwargs = (;
+        # SciMLLogging integrates with the standard logging stack via Base/Core
+        # internals that are not (and cannot be made) public:
+        #   Core.println; Base.CoreLogging.{current_logger_for_env,shouldlog,handle_message}
+        # (src/utils.jl). `CoreLogging` is itself a non-public submodule of `Base`.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :CoreLogging, :current_logger_for_env, :handle_message,
+                :println, :shouldlog,
+            ),
+        ),
+    )
+)
+
+# Functional inference regression test: emitting messages under a `None()` preset
+# must stay type-stable / allocation-free (no fallback to the dynamic logging path).
 @verbosity_specifier JETTestVerbosity begin
     toggles = (:a, :b, :c)
 


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled (all 6 checks).

## What changed
- `test/qa/qa.jl`: the hand-rolled JET-only QA is replaced with `run_qa(SciMLLogging; explicit_imports = true, ...)`, which drives, from the released harness:
  - **Aqua** `test_all` — 8 sub-checks
  - **ExplicitImports** — all 6 checks
  - **JET** `test_package` (typo mode)
- The existing `@test_opt` None()-preset inference regression test is **preserved** as a distinct functional check (it verifies `@SciMLMessage` under `None()` stays type-stable; it is not a `run_qa` tool, so it lives alongside the `run_qa` call).
- Moved ExplicitImports off the Core group: deleted `test/explicit_imports.jl` (which only ran 2 of 6 checks) and dropped `ExplicitImports` from the root test target — it is now transitive via SciMLTesting in the QA sub-env.
- `test/qa/Project.toml`: added **Aqua** as a direct dep (`Aqua.test_ambiguities` spawns a child process that needs Aqua resolvable), bumped `SciMLTesting` compat to `"1.6"`, dropped the now-unused `SafeTestsets`. Root `[compat]` SciMLTesting also bumped to `"1.6"`.

## ExplicitImports findings
- **5 of 6 checks pass clean** with no curation: `no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`, `all_explicit_imports_are_public`.
- **`all_qualified_accesses_are_public`**: ignores 5 non-public names from `Base`/`Core` that SciMLLogging uses (and cannot make public) to integrate with the standard logging stack — `Core.println` and `Base.CoreLogging.{current_logger_for_env, shouldlog, handle_message}`, plus the non-public `Base.CoreLogging` submodule itself (`src/utils.jl`). Documented inline.
- **No `aqua_broken` / `jet_broken` / `ei_broken`** — nothing is known-broken; Aqua 11/11, JET clean (0 reports), EI 6/6.

## Verification (local, released SciMLTesting 1.6.0)
QA group via the folder-model `run_tests()`:
```
QA/qa.jl  |  19  19   (0 Fail / 0 Error / 0 Broken)
  Aqua.test_all     11/11
  ExplicitImports    6/6
  JET test_package   1/1
  @test_opt None()   1/1
```
Core group still green after the EI move (`basics.jl` 33/33, `generation_test.jl` 134/134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)