### PR TITLE
Audit public API documentation coverage

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,10 +2,14 @@
 const LOGGING_BACKEND = @load_preference("logging_backend", "logging")
 
 """
-    `AbstractVerbositySpecifier`
+    AbstractVerbositySpecifier{Enabled}
 
 Base for types which specify which log messages are emitted at what level.
-    
+
+# Type Parameters
+
+- `Enabled`: Boolean type parameter used to specialize enabled and disabled
+  verbosity configurations.
 """
 abstract type AbstractVerbositySpecifier{Enabled} end
 
@@ -110,20 +114,21 @@ end
 
 
 """
-    `@SciMLMessage(message, verbosity::AbstractVerbositySpecifier, option::Symbol)`
-    `@SciMLMessage(message, verbosity::Bool)`
+    @SciMLMessage(message, verbosity::AbstractVerbositySpecifier, option::Symbol[, kwargs...])
+    @SciMLMessage(message, verbosity::Bool[, kwargs...])
 
-A macro that emits a log message based on the log level specified in the `option` of the `AbstractVerbositySpecifier` supplied.
+Emit a log message controlled by a verbosity specifier or boolean flag.
 
-`f_or_message` may be a message String, or a 0-argument function that returns a String.
+`message` may be a string or a zero-argument function that returns a string.
 
-## Usage
+# Arguments
 
-To emit a simple string, `@SciMLMessage("message", verbosity, :option)` will emit a log message with the LogLevel specified in `verbosity` for the given `option`.
+- `message`: Message string or zero-argument message-producing function.
+- `verbosity`: `AbstractVerbositySpecifier` instance or `Bool` controlling emission.
+- `option`: Field name in `verbosity` that selects the message category.
+- `kwargs...`: Optional key-value metadata forwarded to Julia's logging system.
 
-`@SciMLMessage` can also be used to emit a log message coming from the evaluation of a 0-argument function. This function is resolved in the environment of the macro call.
-Therefore it can use variables from the surrounding environment. This may be useful if the log message writer wishes to carry out some calculations using existing variables
-and use them in the log message. The function is only called if the message category is not `Silent`, avoiding unnecessary computation.
+# Examples
 
 The macro works with any `AbstractVerbositySpecifier` implementation:
 
@@ -228,30 +233,30 @@ macro SciMLMessage(f_or_message, verb)
 end
 
 """
-        `verbosity_to_int(verb::MessageLevel)`
+    verbosity_to_int(verb::MessageLevel)
 
-    Takes a `MessageLevel` and gives a corresponding integer value.
-    Verbosity settings that use integers or enums that hold integers are relatively common.
-    This provides an interface so that these packages can be used with SciMLVerbosity. Each of the basic verbosity levels
-    are mapped to an integer.
+Convert a `MessageLevel` to its integer value.
 
-    ```julia
+This is useful when integrating with APIs that represent verbosity as an
+integer or integer-backed enum.
 
-    using SciMLLogging
+# Arguments
 
-    # Standard levels
+- `verb`: Message level to convert.
 
-    verbosity_to_int(Silent)        # Returns 0
-    verbosity_to_int(DebugLevel)    # Returns 1
-    verbosity_to_int(InfoLevel)     # Returns 2
-    verbosity_to_int(WarnLevel)     # Returns 3
-    verbosity_to_int(ErrorLevel)    # Returns 4
+# Returns
 
-    # Custom levels
+The integer severity for `verb`.
 
-    verbosity_to_int(MessageLevel(10)) # Returns 10
-    verbosity_to_int(MessageLevel(-5)) # Returns -5
-    ```
+# Examples
+
+```julia
+using SciMLLogging
+
+verbosity_to_int(Silent)           # returns 0
+verbosity_to_int(InfoLevel)        # returns 2
+verbosity_to_int(MessageLevel(10)) # returns 10
+```
 """
 function verbosity_to_int(verb::MessageLevel)
     verb == Silent     && return 0
@@ -263,38 +268,47 @@ function verbosity_to_int(verb::MessageLevel)
 end
 
 """
-        `verbosity_to_bool(verb::MessageLevel)`
+    verbosity_to_bool(verb::MessageLevel)
 
-    Takes a `MessageLevel` and gives a corresponding boolean value.
-    Verbosity settings that use booleans are relatively common.
-    This provides an interface so that these packages can be used with SciMLVerbosity.
-    If the verbosity is `Silent`, then `false` is returned. Otherwise, `true` is returned.
+Convert a `MessageLevel` to a boolean verbosity flag.
 
-    ```julia
-    using SciMLLogging
+`Silent` maps to `false`; every other message level maps to `true`.
 
-    # Silent returns false
-    verbosity_to_bool(Silent)        # Returns false
+# Arguments
 
-    # All other levels return true
-    verbosity_to_bool(InfoLevel)     # Returns true
-    verbosity_to_bool(WarnLevel)     # Returns true
-    verbosity_to_bool(ErrorLevel)    # Returns true
-    verbosity_to_bool(MessageLevel(5))  # Returns true
-    ```
+- `verb`: Message level to convert.
 
+# Returns
+
+`true` when `verb` emits messages, and `false` when it is `Silent`.
+
+# Examples
+
+```julia
+using SciMLLogging
+
+verbosity_to_bool(Silent)       # returns false
+verbosity_to_bool(WarnLevel)    # returns true
+verbosity_to_bool(MessageLevel(5))
+```
 """
 function verbosity_to_bool(verb::MessageLevel)
     return verb != Silent
 end
 
 """
-    `set_logging_backend(backend::String)``
+    set_logging_backend(backend::String)
 
-Set the logging backend preference. Valid options are:
-- "logging": Use Julia's standard Logging system (default)
-- "core": Use Core.println for simple output
-- "tracy": Use Tracy.jl tracymsg for profiling (requires Tracy.jl to be loaded)
+Set the logging backend preference.
+
+# Arguments
+
+- `backend`: Backend name. Valid values are `"logging"`, `"core"`, and `"tracy"`.
+
+# Returns
+
+Returns `nothing` after updating the preference, or throws `ArgumentError` for
+an invalid backend.
 
 Note: You must restart Julia for this preference change to take effect.
 """
@@ -308,9 +322,13 @@ function set_logging_backend(backend::String)
 end
 
 """
-    `get_logging_backend()`
+    get_logging_backend()
 
 Get the current logging backend preference.
+
+# Returns
+
+The configured backend name as a string.
 """
 function get_logging_backend()
     return @load_preference("logging_backend", "logging")
@@ -322,14 +340,19 @@ end
 Create a logger that routes messages to REPL and/or files based on log level.
 
 # Keyword Arguments
-- `debug_repl = false`: Show debug messages in REPL
-- `info_repl = true`: Show info messages in REPL
-- `warn_repl = true`: Show warnings in REPL
-- `error_repl = true`: Show errors in REPL
-- `debug_file = nothing`: File path for debug messages
-- `info_file = nothing`: File path for info messages
-- `warn_file = nothing`: File path for warnings
-- `error_file = nothing`: File path for errors
+
+- `debug_repl = false`: Show debug messages in the current logger.
+- `info_repl = true`: Show info messages in the current logger.
+- `warn_repl = true`: Show warnings in the current logger.
+- `error_repl = true`: Show errors in the current logger.
+- `debug_file = nothing`: File path for debug messages.
+- `info_file = nothing`: File path for info messages.
+- `warn_file = nothing`: File path for warnings.
+- `error_file = nothing`: File path for errors.
+
+# Returns
+
+A `LoggingExtras.TeeLogger` that routes each log level to the requested sinks.
 """
 function SciMLLogger(;
         debug_repl = false, info_repl = true, warn_repl = true, error_repl = true,

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -1,11 +1,21 @@
 """
-    MessageLevel
+    MessageLevel(level::Integer)
 
-A concrete type representing a log message level, backed by an integer.
+Represent a log message severity, backed by an integer level.
 
 Higher integer values correspond to higher severity. The standard levels are
 available as constants: `Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`, `ErrorLevel`.
 Custom levels can be created with `MessageLevel(n)` for any integer `n`.
+
+# Fields
+
+- `level::Int`: Integer severity used when converting to backend-specific log levels.
+
+# Examples
+
+```julia
+MessageLevel(10)
+```
 """
 struct MessageLevel
     level::Int
@@ -14,35 +24,35 @@ end
 """
     Silent
 
-Log level that produces no output.
+`MessageLevel` that suppresses log emission.
 """
 const Silent = MessageLevel(0)
 
 """
     DebugLevel
 
-Debug log level. Corresponds to `Logging.Debug` when using the Logging backend.
+Debug `MessageLevel`. Corresponds to `Logging.Debug` when using the Logging backend.
 """
 const DebugLevel = MessageLevel(1)
 
 """
     InfoLevel
 
-Informational log level. Corresponds to `Logging.Info` when using the Logging backend.
+Informational `MessageLevel`. Corresponds to `Logging.Info` when using the Logging backend.
 """
 const InfoLevel = MessageLevel(2)
 
 """
     WarnLevel
 
-Warning log level. Corresponds to `Logging.Warn` when using the Logging backend.
+Warning `MessageLevel`. Corresponds to `Logging.Warn` when using the Logging backend.
 """
 const WarnLevel = MessageLevel(3)
 
 """
     ErrorLevel
 
-Error log level. Corresponds to `Logging.Error` when using the Logging backend.
+Error `MessageLevel`. Corresponds to `Logging.Error` when using the Logging backend.
 """
 const ErrorLevel = MessageLevel(4)
 
@@ -52,31 +62,37 @@ const ErrorLevel = MessageLevel(4)
 """
     AbstractVerbosityPreset
 
-Abstract base type for predefined verbosity configurations.
+Base type for predefined verbosity configurations.
 
 Presets provide convenient ways for users to configure verbosity without
 needing to specify individual message categories. Concrete subtypes include:
-- `None`: Disable all verbosity
-- `Minimal`: Only essential messages
-- `Standard`: Balanced verbosity for typical use
-- `Detailed`: Comprehensive verbosity for debugging
-- `All`: Enable all message categories
+
+# Presets
+
+- `None`: Disable all verbosity.
+- `Minimal`: Only essential messages.
+- `Standard`: Balanced verbosity for typical use.
+- `Detailed`: Comprehensive verbosity for debugging.
+- `All`: Enable all message categories.
 """
 abstract type AbstractVerbosityPreset end
 
 """
     None <: AbstractVerbosityPreset
 
-Preset that disables all verbosity. All message categories should be set to to `Silent`.
+Preset that disables all verbosity.
+
+All message categories should be set to `Silent`.
 """
 struct None <: AbstractVerbosityPreset end
 
 """
     Minimal <: AbstractVerbosityPreset
 
-Preset that shows only essential messages. Typically includes only warnings,
-errors, and critical status information while suppressing routine progress
-and debugging messages.
+Preset that shows only essential messages.
+
+Typically includes only warnings, errors, and critical status information while
+suppressing routine progress and debugging messages.
 
 This verbosity preset should set messages related to critical failures and
 errors that stop computation to `ErrorLevel`. Messages related to fatal issues
@@ -89,6 +105,7 @@ struct Minimal <: AbstractVerbosityPreset end
     Standard <: AbstractVerbosityPreset
 
 Preset that provides balanced verbosity suitable for typical usage.
+
 Shows important progress and status information without overwhelming
 the user with details.
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -20,6 +20,90 @@ run_qa(
     )
 )
 
+const EXPECTED_OWNED_PUBLIC_NAMES = Set(
+    Symbol[
+        Symbol("@SciMLMessage"),
+        Symbol("@verbosity_specifier"),
+        :AbstractVerbosityPreset,
+        :AbstractVerbositySpecifier,
+        :All,
+        :DebugLevel,
+        :Detailed,
+        :ErrorLevel,
+        :InfoLevel,
+        :MessageLevel,
+        :Minimal,
+        :None,
+        :SciMLLogger,
+        :Silent,
+        :Standard,
+        :WarnLevel,
+        :get_logging_backend,
+        :set_logging_backend,
+        :verbosity_to_bool,
+        :verbosity_to_int,
+    ]
+)
+
+function owned_public_names(mod)
+    public_names = Set(filter(!=(nameof(mod)), names(mod)))
+
+    if isdefined(Base, :ispublic)
+        ispublic = getproperty(Base, :ispublic)
+        for name in names(mod; all = true, imported = false)
+            name == nameof(mod) && continue
+            startswith(string(name), "#") && continue
+            ispublic(mod, name) && push!(public_names, name)
+        end
+    end
+
+    return public_names
+end
+
+function docs_block_names()
+    docs_root = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+    documented_names = Set{Symbol}()
+
+    for (root, _, files) in walkdir(docs_root)
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs_block = false
+
+            for line in eachline(joinpath(root, file))
+                stripped = strip(line)
+                if startswith(stripped, "```@docs")
+                    in_docs_block = true
+                elseif in_docs_block && startswith(stripped, "```")
+                    in_docs_block = false
+                elseif in_docs_block && !isempty(stripped) && !startswith(stripped, "#")
+                    token = first(split(stripped))
+                    name = replace(token, r"\(.*$" => "")
+                    name = replace(name, r"^SciMLLogging\." => "")
+                    push!(documented_names, Symbol(name))
+                end
+            end
+        end
+    end
+
+    return documented_names
+end
+
+@testset "public API documentation coverage" begin
+    public_names = owned_public_names(SciMLLogging)
+    @test public_names == EXPECTED_OWNED_PUBLIC_NAMES
+
+    metadata = Docs.meta(SciMLLogging)
+    missing_docstrings = sort(
+        [name for name in public_names if !haskey(metadata, Docs.Binding(SciMLLogging, name))];
+        by = string
+    )
+    @test isempty(missing_docstrings)
+
+    rendered_doc_names = docs_block_names()
+    missing_rendered_docs = sort(collect(setdiff(public_names, rendered_doc_names)); by = string)
+    @test isempty(missing_rendered_docs)
+end
+
 # Functional inference regression test: emitting messages under a `None()` preset
 # must stay type-stable / allocation-free (no fallback to the dynamic logging path).
 @verbosity_specifier JETTestVerbosity begin


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Tightens public API docstrings for SciMLLogging-owned exported names in `src/verbosity.jl` and `src/utils.jl`.
- Adds a QA guard that checks the owned public API set, source doc bindings, and docs-source `@docs` coverage.

## Validation

- `git diff --check`
- `julia +1.10 -e 'using Runic; exit(Runic.main(["--check", "src/verbosity.jl", "src/utils.jl", "test/qa/qa.jl"]))'`
- `julia +1.10 --project=. -e 'using Pkg; Pkg.instantiate(); ... public-doc audit ...'`
- `julia +1.10 --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`
- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`