### PR TITLE
Release prep: bump SciMLLogging to 2.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLLogging"
 uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 authors = ["Jadon Clugston"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test scaffolding changes since 2.0.2 (no functional or API changes).