### PR TITLE
Retarget DiffEqBase downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -14,9 +14,9 @@ jobs:
         package:
           - {user: SciML, repo: LinearSolve.jl, group: All}
           - {user: SciML, repo: NonlinearSolve.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream}
-          - {user: SciML, repo: DiffEqBase.jl, group: Downstream2}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Downstream}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Downstream2}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Integrators}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression}
@@ -24,6 +24,7 @@ jobs:
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
       julia-version: "1"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

- replace the archived standalone DiffEqBase repository rows with `OrdinaryDiffEq.jl/lib/DiffEqBase`
- pass that sublibrary project to the shared downstream workflow
- preserve the existing `Core`, `Downstream`, and `Downstream2` coverage

This depends on SciML/.github#115 for reusable-workflow `subdir` support.

## Local verification

- exact workflow-shaped Julia 1.12.6 runs with SciMLLogging developed:
  - `DiffEqBase/Core` — exited 0, `DiffEqBase tests passed`
  - `DiffEqBase/Downstream` — exited 0, `DiffEqBase tests passed`
  - `DiffEqBase/Downstream2` — exited 0, `DiffEqBase tests passed`
- `actionlint .github/workflows/Downstream.yml` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff --check` — passed

Please ignore this PR until it has been reviewed by @ChrisRackauckas.