### PR TITLE
Use standard QA and doctest checks

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,6 @@ makedocs(
     authors = "SciML",
     modules = [SciMLLogging],
     clean = true,
-    doctest = false,
     linkcheck = true,
     checkdocs = :exports,
     format = Documenter.HTML(

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,8 +5,7 @@ using SciMLLogging: @SciMLMessage, @verbosity_specifier,
 using JET
 
 run_qa(
-    SciMLLogging; explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
+    SciMLLogging;
     ei_kwargs = (;
         # SciMLLogging integrates with the standard logging stack via Base/Core
         # internals that are not (and cannot be made) public:


### PR DESCRIPTION
## Summary
- remove redundant SciMLTesting public-doc and explicit-import defaults
- retain the documented irreducible Base/Core logging ExplicitImports exceptions
- enable standard documentation doctests

## Verification
- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`\n- `julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(path = pwd()); Pkg.instantiate(); include("docs/make.jl")'` (doctests passed; external GitHub link check reported HTTP 429)\n- `julia +1.10 --project=. -e 'using Runic; exit(Runic.main(["--check", "src", "test", "docs"]))'`\n\nPlease ignore until reviewed by @ChrisRackauckas.