### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLLogging"
 uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 authors = ["Jadon Clugston"]
-version = "2.0.3"
+version = "2.0.4"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `SciMLLogging` | 2.0.3 | 2.0.4 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).