### PR TITLE
Align logging backend documentation

### DIFF
--- a/docs/src/assets/Project.toml
+++ b/docs/src/assets/Project.toml
@@ -1,6 +1,9 @@
 [deps]
+ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 
 [compat]
+ConcreteStructs = "0.2.3"
 Documenter = "1"
+SciMLLogging = "2.0.0"

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -53,7 +53,7 @@ result = solve(problem, verbose = custom_verbose)
 
 ## Logging Backends
 
-By default, SciMLLogging integrates with Julia's standard logging system, but there is also a backend that uses `Core.println` to emit messages. This is configurable via a [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) preference setting.
+By default, SciMLLogging integrates with Julia's standard logging system, but there is also a backend that uses Julia's public `println` function to emit messages. This is configurable via a [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) preference setting.
 
 ### Standard Julia Logging (Default)
 

--- a/docs/src/manual/backends.md
+++ b/docs/src/manual/backends.md
@@ -40,9 +40,11 @@ open("output.log", "w") do io
 end
 ```
 
-## Core Backend
+## Console Output Backend
 
-Uses `Core.println` for direct console output. Simpler but less flexible. This allows messages to emitted, while still being compatible with static compilation and JuliaC. 
+Uses Julia's public `println` function for direct console output. It is simpler
+but less flexible than the standard logging backend, while remaining compatible
+with static compilation and JuliaC.
 
 ## SciMLLogger
 


### PR DESCRIPTION
## Summary
- document the console backend through Julia's public `println` API
- synchronize the rendered reproducibility project asset with `docs/Project.toml`

## Validation
- `Pkg.test()` (41 core, 134 generation, 3 downstream JET checks)
- standalone strict QA (`run_qa(SciMLLogging)`: 19 checks; JET: 1 check)
- docs build with doctests, exported-doc checks, rendering, and link checking
- `Runic.main(["--check", "."])`
- `git diff --check`

CI diagnosis: PR #90's failing NonlinearSolve downstream Broyden assertion did not reproduce on the same historical downstream revision and SciMLLogging main-equivalent tree; it is an upstream flake. The historical Core rerun later hit unrelated allocation-threshold failures.

Please ignore this PR until reviewed by @ChrisRackauckas.