### PR TITLE
QA: load Tracy so SciMLLoggingTracyExt is actually scanned by ExplicitImports

### DIFF
--- a/ext/SciMLLoggingTracyExt.jl
+++ b/ext/SciMLLoggingTracyExt.jl
@@ -2,7 +2,7 @@ module SciMLLoggingTracyExt
 
 using SciMLLogging
 using SciMLLogging: MessageLevel, DebugLevel, InfoLevel, WarnLevel, ErrorLevel
-using Tracy
+using Tracy: Tracy
 
 # Map MessageLevel values to Tracy color symbols
 function level_to_color(level::MessageLevel)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -4,10 +4,12 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Tracy = "e689c965-62c8-4b79-b2c5-8359227902fd"
 
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.11"
 SciMLTesting = "2.4"
 Test = "1"
+Tracy = "0.1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,7 +4,20 @@ using SciMLLogging: @SciMLMessage, @verbosity_specifier,
     None, Standard
 using JET
 
-run_qa(SciMLLogging)
+# ExplicitImports only sees an extension module once its trigger package is loaded,
+# so load every weakdep here to bring SciMLLoggingTracyExt into the QA scan.
+using Tracy
+
+run_qa(
+    SciMLLogging;
+    ei_kwargs = (;
+        # SciMLLogging: `emit_tracy_message` is the backend hook stub declared in
+        # `src/utils.jl` for `SciMLLoggingTracyExt` to add a method to. It is internal
+        # plumbing rather than user API, so it is deliberately not public, and an
+        # extension has no other way to extend it.
+        all_qualified_accesses_are_public = (; ignore = (:emit_tracy_message,)),
+    )
+)
 
 # Functional inference regression test: emitting messages under a `None()` preset
 # must stay type-stable / allocation-free (no fallback to the dynamic logging path).


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

`SciMLTesting.run_qa` runs the ExplicitImports checks on `SciMLLogging`. ExplicitImports *does* know about package extensions — it reads the `[extensions]` table from `Project.toml` — but it skips any extension whose module does not exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep is loaded, and `test/qa` never loaded Tracy. So `SciMLLoggingTracyExt` was excluded from every ExplicitImports check, and the QA summary looked identical either way (each check folds all submodules into a single `@test`).

## Change

* `test/qa/Project.toml`: add `Tracy` under `[deps]` (same UUID as the root `[weakdeps]`) with `[compat] Tracy = "0.1"` mirroring the root compat bound.
* `test/qa/qa.jl`: `using Tracy` before `run_qa`, with a comment explaining why.

## Coverage proof

Not just "QA still passes" — verified directly from the QA environment:

```
$ julia --project=test/qa -e 'using SciMLLogging, Tracy; ...'
get_extension => SciMLLoggingTracyExt
modules scanned: Module[SciMLLogging, SciMLLoggingTracyExt]
```

`SciMLLoggingTracyExt` is now in the module list ExplicitImports walks. `SciMLLogging` has exactly one extension, so extension coverage is complete — nothing is left out, and no weakdep had to be skipped for hardware/system-library reasons.

## Findings the new coverage produced (2)

1. **`no_implicit_imports`** — `SciMLLoggingTracyExt` relied on an implicit import of the `Tracy` name itself. **Fixed in the extension source**, not ignored: `using Tracy` → `using Tracy: Tracy`. The only use is the qualified `Tracy.tracymsg`, which is public in Tracy, so nothing else changes.

2. **`all_qualified_accesses_are_public`** — `emit_tracy_message` is not public in `SciMLLogging`. Added to the `all_qualified_accesses_are_public` ignore tuple with a comment. Justification: it is the backend hook stub declared as `function emit_tracy_message end` in `src/utils.jl` purely so the Tracy extension can add a method to it. It is internal plumbing, not user API, so it is deliberately not `public`, and an extension has no other spelling available. (ExplicitImports' `allow_internal_accesses` does not help here: an extension module's `Base.moduleroot` is itself, not the parent package, so parent-package accesses from an extension are never classified as internal.)

No check was disabled and nothing was marked `@test_broken`.

## Local runs

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   22     22  1m04.6s
     Testing SciMLLogging tests passed

$ GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary:  | Pass  Total  Time
Core/basics.jl |   41     41  2.4s
Test Summary:           | Pass  Total  Time
Core/generation_test.jl |  134    134  4.3s
     Testing SciMLLogging tests passed
```

Before the fixes, the same QA run was `20 passed, 2 errored` — i.e. the extension really was being checked for the first time.

Runic reports no changes needed on the touched files.
