### PR TITLE
QA: assert SciMLLoggingTracyExt actually loaded before run_qa

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -8,6 +8,12 @@ using JET
 # so load every weakdep here to bring SciMLLoggingTracyExt into the QA scan.
 using Tracy
 
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(SciMLLogging, :SciMLLoggingTracyExt) !== nothing
+end
+
 run_qa(
     SciMLLogging;
     ei_kwargs = (;


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Follow-up to #93 (which was merged before this could be added to it).

## Problem

ExplicitImports adds an extension to the set of checked modules only when it is actually loaded:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

That skip is **silent**. #93 made `test/qa` load `Tracy` so `SciMLLoggingTracyExt` gets scanned, but if the extension ever fails to precompile, `Base.get_extension` returns `nothing`, ExplicitImports quietly skips it, and `run_qa` still reports a clean pass — extension coverage would drop back to zero with no signal. Each ExplicitImports check folds all submodules into a single `@test`, so the summary is byte-identical either way.

## Change

A guard in `test/qa/qa.jl`, before `run_qa`:

```julia
@testset "Extensions loaded" begin
    @test Base.get_extension(SciMLLogging, :SciMLLoggingTracyExt) !== nothing
end
```

Turns the silent skip into a failing test.

## Local run

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   23     23  1m12.5s
     Testing SciMLLogging tests passed
```

23 = the 22 from #93 plus the new guard.

Runic reports no changes needed on the touched file.
