### PR TITLE
Add a module docstring for SciMLLogging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLLogging"
 uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 authors = ["Jadon Clugston"]
-version = "2.0.4"
+version = "2.0.5"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,6 +35,12 @@ If you use SciMLLogging.jl in your research, please cite the SciML organization:
 
 See [Getting Started with SciMLLogging.jl](@ref) for a quick introduction to using SciMLLogging.jl.
 
+## Module
+
+```@docs
+SciMLLogging.SciMLLogging
+```
+
 ## Contributing 
 
 - Please refer to the [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md) for guidance on PRs, issues, and other matters relating to contributing to SciML.

--- a/src/SciMLLogging.jl
+++ b/src/SciMLLogging.jl
@@ -1,3 +1,31 @@
+"""
+    SciMLLogging
+
+Verbosity control for the SciML ecosystem.
+
+SciMLLogging.jl replaces a single `verbose = true` switch with a *verbosity specifier*: a
+struct whose fields each name one category of message a package can emit, and whose value
+per category is a message level (`Silent`, `DebugLevel`, `InfoLevel`, `WarnLevel`,
+`ErrorLevel`). Because the enabled/disabled state lives in the specifier's type
+parameters, a silenced category compiles away rather than being branched over at runtime.
+
+Users of a package that has adopted SciMLLogging pass one of its presets, or set
+categories individually, and hand the result to the solver:
+
+```julia
+using SciMLLogging
+solve(prob, alg; verbose = MyPackageVerbosity(Standard()))
+solve(prob, alg; verbose = MyPackageVerbosity(progress = Silent, diagnostics = WarnLevel))
+```
+
+Package authors declare the specifier type with `@verbosity_specifier`, which generates
+the struct, its constructors and the presets (`None`, `Minimal`, `Standard`, `Detailed`,
+`All`) in one declaration, then emit messages through `@SciMLMessage`. Output goes to
+Julia's standard logging by default; `set_logging_backend` selects an alternative.
+
+See the [SciMLLogging documentation](https://docs.sciml.ai/SciMLLogging/stable/) for the
+full interface.
+"""
 module SciMLLogging
 
 import Logging


### PR DESCRIPTION
## What changed and why

`SciMLLogging` had no module docstring, so `?SciMLLogging` and the manual both showed only Julia's auto-generated "No docstring found for public module SciMLLogging" summary. This adds one — what a verbosity specifier is and how a user passes one to a solver — renders it in the manual (Documenter's `checkdocs` requires every docstring in `modules` to appear in a `@docs` block), and bumps the patch version so it can be released.

This is **hygiene, not a fix.** Nothing depends on it. The undocumented module briefly broke downstream QA lanes, but that was a bug in the checker and is already resolved by SciML/SciMLTesting.jl#45; this PR does not unblock anything. The reason the gap sat here unnoticed is structural: `SciMLTesting.public_api_names` filters out `nameof(pkg)`, so a package is never asked to document its own module, and only a package that *re-exports* `SciMLLogging` ever sees the name in its public API.

## Verification

The docstring is the whole behavioural change, so the discriminating check is the binding itself. `julia +1.12 --project -e 'using REPL, SciMLLogging; Base.Docs.hasdoc(Main, :SciMLLogging)'`:

```
main     54baf34 : hasdoc(:SciMLLogging) = false
this branch       : hasdoc(:SciMLLogging) = true
```

**`GROUP=QA` is unchanged, as expected** — this is the point of the hygiene framing, not an omission. `GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'`:

```
# main 54baf34
Test Summary: | Pass  Total     Time
QA/qa.jl      |   23     23  1m12.2s
     Testing SciMLLogging tests passed

# this branch
Test Summary: | Pass  Total     Time
QA/qa.jl      |   23     23  1m10.5s
     Testing SciMLLogging tests passed
```

The docs build is genuinely green here. `julia +1.12 --project=docs -e 'include("docs/make.jl")'` on this branch:

```
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="2.0.5"` for inventory from ../Project.toml
```

The `@docs` entry in `docs/src/index.md` is load-bearing, not decoration: without it the build fails with

```
┌ Error: 1 docstring not included in the manual:
│     SciMLLogging.SciMLLogging
ERROR: LoadError: `makedocs` encountered an error [:missing_docs] -- terminating build before rendering.
```

Runic (`Runic.main(["--check","--diff","src/SciMLLogging.jl"])`) exits 0; `typos` over the changed files exits 0.

## CI on this PR

All gating checks green:

```
Documentation / Build and Deploy Documentation                pass  4m19s
Runic / Runic Format Check                                    pass  3m39s
Spell Check with Typos                                        pass  8s
downgrade (lts) / Downgrade Tests                             pass  10m31s
tests / QA (julia 1, ubuntu-latest)                           pass  4m35s
```

The downstream fleet (OrdinaryDiffEq, NonlinearSolve, LinearSolve lanes) was not waited on. A docstring cannot affect them, but I did not confirm that.

## Not verified

Julia LTS was not exercised locally (1.12.6 only). Only `GROUP=QA` was run, not `Core` or `Downstream` — the diff is a docstring, a `@docs` entry and a version bump, with no code path touched. The docstring's usage snippet is a plain ```` ```julia ```` block, so it is illustrative and not executed by `doctest`; the `MyPackageVerbosity` name in it is a stand-in for a downstream package's specifier, matching how `docs/src/getting_started.md` already writes it.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75XsVeZ94QH3PmCuq6QUF

